### PR TITLE
Add explicit include for std::stringstream

### DIFF
--- a/src/lib/ExtendedGUID.cpp
+++ b/src/lib/ExtendedGUID.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "ExtendedGUID.h"

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 #include "FileChunkReference.h"
 #include "libone_utils.h"

--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/JCID.cpp
+++ b/src/lib/JCID.cpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <iomanip>
+#include <sstream>
 #include <cstdint>
 #include <librevenge-stream/librevenge-stream.h>
 #include "JCID.h"

--- a/src/lib/ObjectSpaceStreams.cpp
+++ b/src/lib/ObjectSpaceStreams.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/PropertyID.cpp
+++ b/src/lib/PropertyID.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <librevenge-stream/librevenge-stream.h>
 
 #include "PropertyID.h"

--- a/src/lib/PropertySet.cpp
+++ b/src/lib/PropertySet.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <cstdint>
 #include <librevenge-stream/librevenge-stream.h>
 #include "PropertySet.h"

--- a/src/lib/StringInStorageBuffer.cpp
+++ b/src/lib/StringInStorageBuffer.cpp
@@ -11,8 +11,8 @@
 #include <librevenge-stream/librevenge-stream.h>
 #include <unordered_map>
 #include <iostream>
-#include <iostream>
 #include <iomanip>
+#include <sstream>
 #include "StringInStorageBuffer.h"
 #include "libone_utils.h"
 


### PR DESCRIPTION
A small fix:
The compiler complained about the incomplete type `std::stringstream `... 

`<sstream>` is included to declare stringstream completely.
