### PR TITLE
Replace boost with std

### DIFF
--- a/src/conv/raw/one2raw.cpp
+++ b/src/conv/raw/one2raw.cpp
@@ -10,8 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <boost/shared_ptr.hpp>
-
 #include <librevenge/librevenge.h>
 #include <librevenge-generators/librevenge-generators.h>
 #include <librevenge-stream/librevenge-stream.h>

--- a/src/conv/raw/one2raw.cpp
+++ b/src/conv/raw/one2raw.cpp
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <memory>
+
 #include <librevenge/librevenge.h>
 #include <librevenge-generators/librevenge-generators.h>
 #include <librevenge-stream/librevenge-stream.h>

--- a/src/lib/ExtendedGUID.cpp
+++ b/src/lib/ExtendedGUID.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "ExtendedGUID.h"

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 #include "FileChunkReference.h"
 #include "libone_utils.h"

--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <iomanip>

--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/FileNodeChunkReference.cpp
+++ b/src/lib/FileNodeChunkReference.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
 #include <libone/libone.h>
 #include "FileNodeChunkReference.h"
 #include "libone_utils.h"

--- a/src/lib/FileNodeListFragment.cpp
+++ b/src/lib/FileNodeListFragment.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <iomanip>

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/JCID.cpp
+++ b/src/lib/JCID.cpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <iomanip>
+#include <sstream>
 #include <cstdint>
 #include <librevenge-stream/librevenge-stream.h>
 #include "JCID.h"

--- a/src/lib/ONEDocument.cpp
+++ b/src/lib/ONEDocument.cpp
@@ -10,8 +10,6 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <librevenge-stream/librevenge-stream.h>
 

--- a/src/lib/ObjectSpaceStreams.cpp
+++ b/src/lib/ObjectSpaceStreams.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <libone/libone.h>
 
 #include "libone_utils.h"

--- a/src/lib/OneNoteParser.cpp
+++ b/src/lib/OneNoteParser.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
 #include "libone_utils.h"
 #include "libone_types.h"
 #include "OneNoteParser.h"

--- a/src/lib/OneNoteParser.h
+++ b/src/lib/OneNoteParser.h
@@ -16,8 +16,6 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <librevenge-stream/librevenge-stream.h>
 

--- a/src/lib/PropertyID.cpp
+++ b/src/lib/PropertyID.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <librevenge-stream/librevenge-stream.h>
 
 #include "PropertyID.h"

--- a/src/lib/PropertySet.cpp
+++ b/src/lib/PropertySet.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <cstdint>
 #include <librevenge-stream/librevenge-stream.h>
 #include "PropertySet.h"

--- a/src/lib/StringInStorageBuffer.cpp
+++ b/src/lib/StringInStorageBuffer.cpp
@@ -11,8 +11,8 @@
 #include <librevenge-stream/librevenge-stream.h>
 #include <unordered_map>
 #include <iostream>
-#include <iostream>
 #include <iomanip>
+#include <sstream>
 #include "StringInStorageBuffer.h"
 #include "libone_utils.h"
 

--- a/src/lib/libone_utils.cpp
+++ b/src/lib/libone_utils.cpp
@@ -177,57 +177,57 @@ unsigned long getLength(librevenge::RVNGInputStream *const input)
   return end - begin;
 }
 
-uint8_t readU8(const boost::shared_ptr<librevenge::RVNGInputStream> input, bool)
+uint8_t readU8(const std::shared_ptr<librevenge::RVNGInputStream> input, bool)
 {
   return readU8(input.get());
 }
 
-uint16_t readU16(const boost::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
+uint16_t readU16(const std::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
 {
   return readU16(input.get(), bigEndian);
 }
 
-uint32_t readU32(const boost::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
+uint32_t readU32(const std::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
 {
   return readU32(input.get(), bigEndian);
 }
 
-uint64_t readU64(const boost::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
+uint64_t readU64(const std::shared_ptr<librevenge::RVNGInputStream> input, const bool bigEndian)
 {
   return readU64(input.get(), bigEndian);
 }
 
-const unsigned char *readNBytes(const boost::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long numBytes)
+const unsigned char *readNBytes(const std::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long numBytes)
 {
   return readNBytes(input.get(), numBytes);
 }
 
-std::string readCstring(const boost::shared_ptr<librevenge::RVNGInputStream> input)
+std::string readCstring(const std::shared_ptr<librevenge::RVNGInputStream> input)
 {
   return readCstring(input.get());
 }
 
-std::string readPascalstring(const boost::shared_ptr<librevenge::RVNGInputStream> input)
+std::string readPascalstring(const std::shared_ptr<librevenge::RVNGInputStream> input)
 {
   return readPascalstring(input.get());
 }
 
-void skip(const boost::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long numBytes)
+void skip(const std::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long numBytes)
 {
   return skip(input.get(), numBytes);
 }
 
-void seek(const boost::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long pos)
+void seek(const std::shared_ptr<librevenge::RVNGInputStream> input, const unsigned long pos)
 {
   seek(input.get(), pos);
 }
 
-void seekRelative(const boost::shared_ptr<librevenge::RVNGInputStream> input, const long pos)
+void seekRelative(const std::shared_ptr<librevenge::RVNGInputStream> input, const long pos)
 {
   seekRelative(input.get(), pos);
 }
 
-unsigned long getLength(const boost::shared_ptr<librevenge::RVNGInputStream> input)
+unsigned long getLength(const std::shared_ptr<librevenge::RVNGInputStream> input)
 {
   return getLength(input.get());
 }

--- a/src/lib/libone_utils.h
+++ b/src/lib/libone_utils.h
@@ -15,9 +15,9 @@
 #include <cstdio>
 #endif
 
+#include <memory>
 #include <string>
 #include <unordered_map>
-#include <boost/shared_ptr.hpp>
 
 #include <librevenge-stream/librevenge-stream.h>
 #include <librevenge/librevenge.h>
@@ -81,7 +81,7 @@ typedef __int64 int64_t;
 namespace libone
 {
 
-typedef boost::shared_ptr<librevenge::RVNGInputStream> RVNGInputStreamPtr_t;
+typedef std::shared_ptr<librevenge::RVNGInputStream> RVNGInputStreamPtr_t;
 
 struct ONEDummyDeleter
 {
@@ -105,22 +105,22 @@ void seekRelative(librevenge::RVNGInputStream *input, long pos);
 
 unsigned long getLength(librevenge::RVNGInputStream *input);
 
-uint8_t readU8(boost::shared_ptr<librevenge::RVNGInputStream> input, bool = false);
-uint16_t readU16(boost::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
-uint32_t readU32(boost::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
-uint64_t readU64(boost::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
+uint8_t readU8(std::shared_ptr<librevenge::RVNGInputStream> input, bool = false);
+uint16_t readU16(std::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
+uint32_t readU32(std::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
+uint64_t readU64(std::shared_ptr<librevenge::RVNGInputStream> input, bool bigEndian=false);
 
-const unsigned char *readNBytes(boost::shared_ptr<librevenge::RVNGInputStream> input, unsigned long numBytes);
+const unsigned char *readNBytes(std::shared_ptr<librevenge::RVNGInputStream> input, unsigned long numBytes);
 
-std::string readCString(boost::shared_ptr<librevenge::RVNGInputStream> input);
-std::string readPascalString(boost::shared_ptr<librevenge::RVNGInputStream> input);
+std::string readCString(std::shared_ptr<librevenge::RVNGInputStream> input);
+std::string readPascalString(std::shared_ptr<librevenge::RVNGInputStream> input);
 
-void skip(boost::shared_ptr<librevenge::RVNGInputStream> input, unsigned long numBytes);
+void skip(std::shared_ptr<librevenge::RVNGInputStream> input, unsigned long numBytes);
 
-void seek(boost::shared_ptr<librevenge::RVNGInputStream> input, unsigned long pos);
-void seekRelative(boost::shared_ptr<librevenge::RVNGInputStream> input, long pos);
+void seek(std::shared_ptr<librevenge::RVNGInputStream> input, unsigned long pos);
+void seekRelative(std::shared_ptr<librevenge::RVNGInputStream> input, long pos);
 
-unsigned long getLength(boost::shared_ptr<librevenge::RVNGInputStream> input);
+unsigned long getLength(std::shared_ptr<librevenge::RVNGInputStream> input);
 
 class EndOfStreamException
 {


### PR DESCRIPTION
This will limited the compiler to C++11 as minimum standard, but would reduce the dependency 

But i have the impression, this can be done without inconvenience.