### PR TITLE
Paranoiac compiler fixes

### DIFF
--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -45,6 +45,7 @@ void FileChunkReference::parse(librevenge::RVNGInputStream *input)
     m_stp = readU64(input, false);
     m_cb = readU32(input, false);
     break;
+  case fcr_size_invalid:
   default:
     ONE_DEBUG_MSG(("FileChunkReference: not good!\n"));
     break;
@@ -96,6 +97,7 @@ bool FileChunkReference::is_fcrNil()
   case Size64x64:
   case Size64x32:
     return (cbval && (m_stp & 0xFFFFFFFFFFFFFFFF));
+  case fcr_size_invalid:
   default:
     return false;
   }

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -56,7 +56,7 @@ long FileChunkReference::get_location()
 {
   return m_stp;
 }
-long FileChunkReference::get_size()
+uint64_t FileChunkReference::get_size()
 {
   return m_cb;
 }

--- a/src/lib/FileChunkReference.h
+++ b/src/lib/FileChunkReference.h
@@ -32,7 +32,7 @@ public:
   void parse(librevenge::RVNGInputStream *input);
   std::string to_string();
   long get_location();
-  long get_size();
+  uint64_t get_size();
   bool is_fcrNil();
   bool is_fcrZero();
   void set_zero();

--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -83,6 +83,69 @@ std::string fnd_id_to_string(enum fnd_id id_fnd)
   case fnd_id::ObjectGroupEndFND:
     stream << "ObjectGroupEndFND";
     break;
+  case fnd_id::GlobalIdTableStartFNDX:
+    stream << "GlobalIdTableStartFNDX";
+    break;
+  case fnd_id::GlobalIdTableEntry2FNDX:
+    stream << "GlobalIdTableEntry2FNDX";
+    break;
+  case fnd_id::GlobalIdTableEntry3FNDX:
+    stream << "GlobalIdTableEntry3FNDX";
+    break;
+  case fnd_id::ObjectDeclarationWithRefCountFNDX:
+    stream << "ObjectDeclarationWithRefCountFNDX";
+    break;
+  case fnd_id::ObjectDeclarationWithRefCount2FNDX:
+    stream << "ObjectDeclarationWithRefCount2FNDX";
+    break;
+  case fnd_id::ObjectRevisionWithRefCountFNDX:
+    stream << "ObjectRevisionWithRefCountFNDX";
+    break;
+  case fnd_id::ObjectRevisionWithRefCount2FNDX:
+    stream << "ObjectRevisionWithRefCount2FNDX";
+    break;
+  case fnd_id::RootObjectReference2FNDX:
+    stream << "RootObjectReference2FNDX";
+    break;
+  case fnd_id::RootObjectReference3FND:
+    stream << "RootObjectReference3FND";
+    break;
+  case fnd_id::RevisionRoleDeclarationFND:
+    stream << "RevisionRoleDeclarationFND";
+    break;
+  case fnd_id::RevisionRoleAndContextDeclarationFND:
+    stream << "RevisionRoleAndContextDeclarationFND";
+    break;
+  case fnd_id::ObjectDeclarationFileData3RefCountFND:
+    stream << "ObjectDeclarationFileData3RefCountFND";
+    break;
+  case fnd_id::ObjectDeclarationFileData3LargeRefCountFND:
+    stream << "ObjectDeclarationFileData3LargeRefCountFND";
+    break;
+  case fnd_id::ObjectDataEncryptionKeyV2FNDX:
+    stream << "ObjectDataEncryptionKeyV2FNDX";
+    break;
+  case fnd_id::ObjectInfoDependencyOverridesFND:
+    stream << "ObjectInfoDependencyOverridesFND";
+    break;
+  case fnd_id::FileDataStoreObjectReferenceFND:
+    stream << "FileDataStoreObjectReferenceFND";
+    break;
+  case fnd_id::ObjectDeclaration2LargeRefCountFND:
+    stream << "ObjectDeclaration2LargeRefCountFND";
+    break;
+  case fnd_id::HashedChunkDescriptor2FND:
+    stream << "HashedChunkDescriptor2FND";
+    break;
+  case fnd_id::ReadOnlyObjectDeclaration2RefCountFND:
+    stream << "ReadOnlyObjectDeclaration2RefCountFND";
+    break;
+  case fnd_id::ReadOnlyObjectDeclaration2LargeRefCountFND:
+    stream << "ReadOnlyObjectDeclaration2LargeRefCountFND";
+    break;
+  case fnd_id::RevisionManifestEndFND:
+    stream << "RevisionManifestEndFND";
+    break;
   case fnd_id::fnd_invalid_id:
   default:
     stream << "dunno but value is " << id_fnd;
@@ -123,6 +186,22 @@ void FileNode::parse(librevenge::RVNGInputStream *input)
   case fnd_id::ObjectDeclarationFileData3RefCountFND:
   case fnd_id::ReadOnlyObjectDeclaration2RefCountFND:
   case fnd_id::FileDataStoreObjectReferenceFND:
+  case fnd_id::GlobalIdTableStartFNDX:
+  case fnd_id::GlobalIdTableEntry2FNDX:
+  case fnd_id::GlobalIdTableEntry3FNDX:
+  case fnd_id::ObjectDeclarationWithRefCountFNDX:
+  case fnd_id::ObjectDeclarationWithRefCount2FNDX:
+  case fnd_id::ObjectRevisionWithRefCountFNDX:
+  case fnd_id::ObjectRevisionWithRefCount2FNDX:
+  case fnd_id::RootObjectReference2FNDX:
+  case fnd_id::RevisionRoleDeclarationFND:
+  case fnd_id::RevisionRoleAndContextDeclarationFND:
+  case fnd_id::ObjectDeclarationFileData3LargeRefCountFND:
+  case fnd_id::ObjectDataEncryptionKeyV2FNDX:
+  case fnd_id::ObjectDeclaration2LargeRefCountFND:
+  case fnd_id::HashedChunkDescriptor2FND:
+  case fnd_id::ReadOnlyObjectDeclaration2LargeRefCountFND:
+  case fnd_id::ChunkTerminatorFND:
     break;
   case fnd_id::fnd_invalid_id:
   default:
@@ -152,6 +231,7 @@ std::string FileNode::to_string()
   case fnd_ref_filenodelist:
     stream << "fnd_ref_filenodelist@0x" << m_fnd.get_location();
     break;
+  case fnd_invalid_basetype:
   default:
     stream << "UNKNOWN BASETYPE";
     assert(false);
@@ -196,6 +276,7 @@ void FileNode::parse_header(librevenge::RVNGInputStream *input)
   case fnd_no_data:
     reference.set_zero();
     break;
+  case fnd_invalid_basetype:
   default:
     assert(false);
     break;

--- a/src/lib/FileNode.h
+++ b/src/lib/FileNode.h
@@ -97,14 +97,14 @@ public:
   {
     return m_fnd;
   }
-  uint32_t get_location()
+  uint64_t get_location()
   {
     return m_offset;
   }
 
   static const uint32_t header_size = sizeof(uint32_t);
 private:
-  uint32_t m_offset = 0;
+  uint64_t m_offset = 0;
   uint32_t m_size_in_file = 0;
   uint32_t m_header_size = 0;
   enum fnd_id m_fnd_id = fnd_invalid_id;

--- a/src/lib/FileNodeChunkReference.cpp
+++ b/src/lib/FileNodeChunkReference.cpp
@@ -38,6 +38,7 @@ bool FileNodeChunkReference::is_fcrNil()
   case stp_compressed_2:
     return (cbval && (m_stp & 0xFFFF));
 
+  case stp_invalid:
   default:
     return false;
   }

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -74,13 +74,13 @@ void GUID::from_string(std::string str)
 {
   ONE_DEBUG_MSG(("\n"));
 
-  Data1 = strtol(str.substr(0, 8).c_str(), NULL, 16);
-  Data2 = strtol(str.substr(9, 4).c_str(), NULL, 16);
-  Data3 = strtol(str.substr(14, 4).c_str(), NULL, 16);
-  Data4[0] = strtol(str.substr(19, 4).c_str(), NULL, 16);
-  Data4[1] = strtol(str.substr(24, 4).c_str(), NULL, 16);
-  Data4[2] = strtol(str.substr(28, 4).c_str(), NULL, 16);
-  Data4[3] = strtol(str.substr(32, 4).c_str(), NULL, 16);
+  Data1 = (uint32_t) strtol(str.substr(0, 8).c_str(), NULL, 16);
+  Data2 = (uint16_t) strtol(str.substr(9, 4).c_str(), NULL, 16);
+  Data3 = (uint16_t) strtol(str.substr(14, 4).c_str(), NULL, 16);
+  Data4[0] = (uint16_t) strtol(str.substr(19, 4).c_str(), NULL, 16);
+  Data4[1] = (uint16_t) strtol(str.substr(24, 4).c_str(), NULL, 16);
+  Data4[2] = (uint16_t) strtol(str.substr(28, 4).c_str(), NULL, 16);
+  Data4[3] = (uint16_t) strtol(str.substr(32, 4).c_str(), NULL, 16);
 
   ONE_DEBUG_MSG((" from string, dat good?\n"));
 

--- a/src/lib/ObjectSpaceStreams.cpp
+++ b/src/lib/ObjectSpaceStreams.cpp
@@ -46,7 +46,7 @@ uint16_t ObjectSpaceStream::get_A()
   return a;
 }
 
-uint16_t ObjectSpaceStream::get_B()
+uint32_t ObjectSpaceStream::get_B()
 {
   return b;
 }

--- a/src/lib/ObjectSpaceStreams.h
+++ b/src/lib/ObjectSpaceStreams.h
@@ -29,14 +29,14 @@ public:
   std::string header_string();
   virtual ~ObjectSpaceStream() { };
   uint16_t get_A();
-  uint16_t get_B();
+  uint32_t get_B();
   uint32_t get_Count();
 
   virtual std::vector<ExtendedGUID> parse(librevenge::RVNGInputStream *input) = 0;
 protected:
   uint32_t Count = 0;
   uint16_t a = 0;
-  uint16_t b = 0;
+  uint32_t b = 0;
 };
 
 class ObjectSpaceStreamOfOIDs: public ObjectSpaceStream

--- a/src/lib/OneNoteParser.cpp
+++ b/src/lib/OneNoteParser.cpp
@@ -88,7 +88,47 @@ void OneNoteParser::parse_root_file_node_list(librevenge::RVNGInputStream *input
       object_space.parse(input, node);
       break;
     case FileDataStoreListReferenceFND:
+    // TODO: The majority of these file nodes do not appear in
+    // the root file node list. Maybe do some more paranoiac checks
+    // to that effect instead of just breaking out of the switch.
+    case ObjectSpaceManifestListStartFND:
+    case RevisionManifestListReferenceFND:
+    case RevisionManifestListStartFND:
+    case RevisionManifestStart4FND:
+    case RevisionManifestEndFND:
+    case RevisionManifestStart6FND:
+    case RevisionManifestStart7FND:
+    case GlobalIdTableStartFNDX:
+    case GlobalIdTableStart2FND:
+    case GlobalIdTableEntryFNDX:
+    case GlobalIdTableEntry2FNDX:
+    case GlobalIdTableEntry3FNDX:
+    case GlobalIdTableEndFNDX:
+    case ObjectDeclarationWithRefCountFNDX:
+    case ObjectDeclarationWithRefCount2FNDX:
+    case ObjectRevisionWithRefCountFNDX:
+    case ObjectRevisionWithRefCount2FNDX:
+    case RootObjectReference2FNDX:
+    case RootObjectReference3FND:
+    case RevisionRoleDeclarationFND:
+    case RevisionRoleAndContextDeclarationFND:
+    case ObjectDeclarationFileData3RefCountFND:
+    case ObjectDeclarationFileData3LargeRefCountFND:
+    case ObjectDataEncryptionKeyV2FNDX:
+    case ObjectInfoDependencyOverridesFND:
+    case DataSignatureGroupDefinitionFND:
+    case FileDataStoreObjectReferenceFND:
+    case ObjectDeclaration2RefCountFND:
+    case ObjectDeclaration2LargeRefCountFND:
+    case ObjectGroupListReferenceFND:
+    case ObjectGroupStartFND:
+    case ObjectGroupEndFND:
+    case HashedChunkDescriptor2FND:
+    case ReadOnlyObjectDeclaration2RefCountFND:
+    case ReadOnlyObjectDeclaration2LargeRefCountFND:
+    case ChunkTerminatorFND:
       break;
+    case fnd_invalid_id:
     default:
       assert(false);
       break;

--- a/src/lib/PropertyID.cpp
+++ b/src/lib/PropertyID.cpp
@@ -41,7 +41,8 @@ uint32_t PropertyID::get_type()
 
 uint16_t PropertyID::get_bool_value()
 {
-  return (val & 0x80000000) >> 31;
+  /* TODO: this could be converted to return a real boolean */
+  return (uint16_t) ((val & 0x80000000) >> 31);
 }
 
 

--- a/src/lib/StringInStorageBuffer.cpp
+++ b/src/lib/StringInStorageBuffer.cpp
@@ -24,7 +24,7 @@ void StringInStorageBuffer::parse(librevenge::RVNGInputStream *input)
   std::stringstream stream;
   length = readU32(input);
   std::vector<char> string;
-  char *buf = (char *) readNBytes(input, length*2);
+  const unsigned char *buf = readNBytes(input, length*2);
   string.assign(buf, buf+length*2);
   ustring = librevenge::RVNGString((char *) &string[0]);
 

--- a/src/lib/TransactionLog.cpp
+++ b/src/lib/TransactionLog.cpp
@@ -19,7 +19,7 @@
 namespace libone
 {
 
-TransactionLog::TransactionLog(uint64_t location, uint32_t size, uint32_t max_transactions) :
+TransactionLog::TransactionLog(uint64_t location, uint64_t size, uint32_t max_transactions) :
   m_offset(location), m_size(size), m_total_transactions(max_transactions),
   m_fragments(std::vector<TransactionLogFragment>()),
   m_transactions(std::vector<TransactionEntry>())
@@ -32,11 +32,11 @@ void TransactionLog::parse(librevenge::RVNGInputStream *input)
 {
   TransactionLogFragment fragment = TransactionLogFragment();
   uint64_t location = m_offset;
-  uint32_t transactions_parsed = 0;
+  uint64_t transactions_parsed = 0;
 
   DBMSG << "begin, input@" << input->tell() << std::endl;
 
-  for (uint32_t i=0; i<m_total_transactions;)
+  for (uint64_t i=0; i<m_total_transactions;)
   {
     DBMSG << "seeking to fragment @" << location << std::endl;
     input->seek(location, librevenge::RVNG_SEEK_SET);

--- a/src/lib/TransactionLog.h
+++ b/src/lib/TransactionLog.h
@@ -19,7 +19,7 @@ namespace libone
 class TransactionLog
 {
 public:
-  TransactionLog(uint64_t location, uint32_t size, uint32_t max_transactions);
+  TransactionLog(uint64_t location, uint64_t size, uint32_t max_transactions);
   void parse(librevenge::RVNGInputStream *input);
   std::string to_string();
   uint32_t get_srcID();
@@ -27,8 +27,8 @@ public:
 
 private:
   uint64_t m_offset;
-  uint32_t m_size;
-  uint32_t m_total_transactions;
+  uint64_t m_size;
+  uint64_t m_total_transactions;
   std::vector<TransactionLogFragment> m_fragments;
   std::vector<TransactionEntry> m_transactions;
 

--- a/src/lib/TransactionLogFragment.cpp
+++ b/src/lib/TransactionLogFragment.cpp
@@ -27,9 +27,9 @@ TransactionLogFragment::TransactionLogFragment() :
 {}
 
 
-int TransactionLogFragment::parse(librevenge::RVNGInputStream *input,
-                                  uint64_t location, uint32_t size,
-                                  uint32_t transactions_to_parse)
+uint64_t TransactionLogFragment::parse(librevenge::RVNGInputStream *input,
+                                  uint64_t location, uint64_t size,
+                                  uint64_t transactions_to_parse)
 {
   m_offset = location;
   m_size = size;
@@ -49,6 +49,7 @@ int TransactionLogFragment::parse(librevenge::RVNGInputStream *input,
 
   DBMSG << "Parsed chunk referece pointing to " << m_next_fragment.get_location() << std::endl;
 
+  // TODO: check if the int does not overflow, maybe change to another type
   return m_transactions.size();
 }
 

--- a/src/lib/TransactionLogFragment.h
+++ b/src/lib/TransactionLogFragment.h
@@ -20,9 +20,9 @@ class TransactionLogFragment
 {
 public:
   TransactionLogFragment();
-  int parse(librevenge::RVNGInputStream *input,
-            uint64_t location, uint32_t size,
-            uint32_t transactions_to_parse);
+  uint64_t parse(librevenge::RVNGInputStream *input,
+            uint64_t location, uint64_t size,
+            uint64_t transactions_to_parse);
   std::string to_string();
   std::vector<TransactionEntry> &get_transactions()
   {
@@ -35,8 +35,8 @@ public:
 
 private:
   uint64_t m_offset;
-  uint32_t m_size;
-  uint32_t m_transactions_to_parse;
+  uint64_t m_size;
+  uint64_t m_transactions_to_parse;
 
   std::vector<TransactionEntry> m_transactions;
   FileChunkReference m_next_fragment;


### PR DESCRIPTION
This PR's objective is to fix all the fallout created by the paranoiac compiler options introduced in #10. This is kept separate from the Meson changes, as these only touch the codebase itself, so it could be independently merged of the build system changes.

The changes are mostly mechanical and some classes touched already have a need to be rewritten before these changes, but at least it will get us to successfully compiling the library with the paranoiac options turned on.