### PR TITLE
fix GUID.to_string() and add Tests

### DIFF
--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -122,7 +122,7 @@ bool GUID::is_equal(const GUID other) const
 }
 
 // This is used for FileDataStores. The GUID is given as a string in the file
-void GUID::from_string(std::string const str)
+void GUID::from_string(const std::string str)
 {
   ONE_DEBUG_MSG(("\n"));
 

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -8,12 +8,14 @@
  */
 
 
+#include <array>
 #include <cstddef>
 #include <cstring>
 #include <cstdio>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+
 #include <libone/libone.h>
 
 #include "libone_utils.h"
@@ -23,13 +25,57 @@
 namespace libone
 {
 
+// {FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}
+enum { MaxStringGUIDLength = 38};
+// FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+enum { MinStringGUIDLength = 32};
+
+GUID::GUID() :
+  Data1(0), Data2(0), Data3(0), Data4({0,0,0,0})
+{
+}
+
+GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
+           const std::array<uint16_t,4> data4) :
+  Data1(data1), Data2(data2), Data3(data3), Data4(data4) {}
+
+
+GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
+           const uint16_t data4_1, const uint16_t data4_2,
+           const uint16_t data4_3, const uint16_t data4_4) :
+  Data1(data1), Data2(data2), Data3(data3), Data4({data4_1, data4_2, data4_3, data4_4})
+{
+}
+
+uint32_t GUID::data1() const
+{
+  return Data1;
+}
+
+uint16_t GUID::data2() const
+{
+  return Data2;
+}
+
+uint16_t GUID::data3() const
+{
+  return Data3;
+}
+
+std::array<uint16_t, 4> GUID::data4() const
+{
+  return Data4;
+}
+
 void GUID::zero()
 {
   Data1 = 0;
   Data2 = 0;
   Data3 = 0;
   for (int i=0; i < 4; i++)
+  {
     Data4[i] = 0;
+  }
 }
 
 void GUID::parse(librevenge::RVNGInputStream *input)
@@ -38,22 +84,28 @@ void GUID::parse(librevenge::RVNGInputStream *input)
   Data2 = readU16(input, false);
   Data3 = readU16(input, false);
   for (int i=0; i<4; i++)
+  {
     Data4[i] = readU16(input, true);
+  }
 }
 
-std::string GUID::to_string()
+std::string GUID::to_string() const
 {
   std::stringstream stream;
-  stream << "{" << std::hex << Data1 << "-" << Data2 << "-" << Data3 << "-" << Data4[0] << "-";
+  stream << "{" <<  int_to_hex(Data1) << "-" << int_to_hex(Data2) << "-" << int_to_hex(Data3) << "-" << int_to_hex(Data4[0]) << "-";
 
   for (int i=1; i<4; i++)
-    stream << std::hex << Data4[i];
+  {
+    stream << int_to_hex(Data4[i]);
+  }
 
   stream << "}";
+
   return stream.str();
 }
 
-bool GUID::is_equal(GUID other)
+
+bool GUID::is_equal(const GUID other) const
 {
   if ((Data1 == other.Data1) &&
       (Data2 == other.Data2) &&
@@ -70,20 +122,72 @@ bool GUID::is_equal(GUID other)
 }
 
 // This is used for FileDataStores. The GUID is given as a string in the file
-void GUID::from_string(std::string str)
+void GUID::from_string(std::string const str)
 {
   ONE_DEBUG_MSG(("\n"));
 
-  Data1 = strtol(str.substr(0, 8).c_str(), NULL, 16);
-  Data2 = strtol(str.substr(9, 4).c_str(), NULL, 16);
-  Data3 = strtol(str.substr(14, 4).c_str(), NULL, 16);
-  Data4[0] = strtol(str.substr(19, 4).c_str(), NULL, 16);
-  Data4[1] = strtol(str.substr(24, 4).c_str(), NULL, 16);
-  Data4[2] = strtol(str.substr(28, 4).c_str(), NULL, 16);
-  Data4[3] = strtol(str.substr(32, 4).c_str(), NULL, 16);
+  if (str.size() < MinStringGUIDLength)
+  {
+    return;
+  }
+
+  if (str.front() == '{' && str.size() > MaxStringGUIDLength)
+  {
+    return;
+  }
+
+
+  size_t i{0};
+  str.at(i) == '{' ? i++ : 0;
+
+  Data1 = strtol(str.substr(i,8).c_str(), NULL, 16);
+  i += 8;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data2 = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data3 = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data4[0] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data4[1] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  Data4[2] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  Data4[3] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
 
   ONE_DEBUG_MSG((" from string, dat good?\n"));
 
-  (void) str;
 }
+
+
+librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj)
+{
+  obj.parse(input);
+  return input;
 }
+
+bool operator==(const GUID &lhs, const GUID &rhs) noexcept
+{
+  return lhs.is_equal(rhs);
+}
+
+bool operator!=(const GUID &lhs, const GUID &rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+} // namespace libone

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -49,7 +49,48 @@ GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
 
 GUID::GUID(std::string const str) : GUID()
 {
-  this->from_string(str);
+  if (str.size() < MinStringGUIDLength)
+  {
+    return;
+  }
+
+  if (str.front() == '{' && str.size() > MaxStringGUIDLength)
+  {
+    return;
+  }
+
+
+  size_t i {};
+  str.at(i) == '{' ? i++ : 0;
+
+  Data1 = (uint32_t) strtol(str.substr(i,8).c_str(), NULL, 16);
+  i += 8;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data2 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data3 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data4[0] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  str.at(i) == '-' ? i++ : 0;
+
+  Data4[1] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  Data4[2] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
+
+  Data4[3] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
+  i += 4;
 }
 
 uint32_t GUID::data1() const
@@ -125,57 +166,6 @@ bool GUID::is_equal(const GUID other) const
   }
   return false;
 }
-
-// This is used for FileDataStores. The GUID is given as a string in the file
-void GUID::from_string(const std::string str)
-{
-
-  if (str.size() < MinStringGUIDLength)
-  {
-    return;
-  }
-
-  if (str.front() == '{' && str.size() > MaxStringGUIDLength)
-  {
-    return;
-  }
-
-
-  size_t i {};
-  str.at(i) == '{' ? i++ : 0;
-
-  Data1 = (uint32_t) strtol(str.substr(i,8).c_str(), NULL, 16);
-  i += 8;
-
-  str.at(i) == '-' ? i++ : 0;
-
-  Data2 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-  str.at(i) == '-' ? i++ : 0;
-
-  Data3 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-  str.at(i) == '-' ? i++ : 0;
-
-  Data4[0] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-  str.at(i) == '-' ? i++ : 0;
-
-  Data4[1] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-  Data4[2] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-  Data4[3] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
-  i += 4;
-
-
-}
-
 
 librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj)
 {

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -26,9 +26,9 @@ namespace libone
 {
 
 // {FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}
-enum { MaxStringGUIDLength = 38};
+static const int8_t MaxStringGUIDLength = 38;
 // FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-enum { MinStringGUIDLength = 32};
+static const int8_t MinStringGUIDLength = 32;
 
 GUID::GUID() :
   Data1(0), Data2(0), Data3(0), Data4{{0,0,0,0}}
@@ -45,6 +45,11 @@ GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
            const uint16_t data4_3, const uint16_t data4_4) :
   Data1(data1), Data2(data2), Data3(data3), Data4{{data4_1, data4_2, data4_3, data4_4}}
 {
+}
+
+GUID::GUID(std::string const str) : GUID()
+{
+  this->from_string(str);
 }
 
 uint32_t GUID::data1() const
@@ -124,7 +129,6 @@ bool GUID::is_equal(const GUID other) const
 // This is used for FileDataStores. The GUID is given as a string in the file
 void GUID::from_string(const std::string str)
 {
-  ONE_DEBUG_MSG(("\n"));
 
   if (str.size() < MinStringGUIDLength)
   {
@@ -137,7 +141,7 @@ void GUID::from_string(const std::string str)
   }
 
 
-  size_t i{0};
+  size_t i {};
   str.at(i) == '{' ? i++ : 0;
 
   Data1 = (uint32_t) strtol(str.substr(i,8).c_str(), NULL, 16);
@@ -169,7 +173,6 @@ void GUID::from_string(const std::string str)
   Data4[3] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
-  ONE_DEBUG_MSG((" from string, dat good?\n"));
 
 }
 

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -31,7 +31,7 @@ enum { MaxStringGUIDLength = 38};
 enum { MinStringGUIDLength = 32};
 
 GUID::GUID() :
-  Data1(0), Data2(0), Data3(0), Data4({0,0,0,0})
+  Data1(0), Data2(0), Data3(0), Data4{{0,0,0,0}}
 {
 }
 
@@ -43,7 +43,7 @@ GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
 GUID::GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
            const uint16_t data4_1, const uint16_t data4_2,
            const uint16_t data4_3, const uint16_t data4_4) :
-  Data1(data1), Data2(data2), Data3(data3), Data4({data4_1, data4_2, data4_3, data4_4})
+  Data1(data1), Data2(data2), Data3(data3), Data4{{data4_1, data4_2, data4_3, data4_4}}
 {
 }
 

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -140,33 +140,33 @@ void GUID::from_string(std::string const str)
   size_t i{0};
   str.at(i) == '{' ? i++ : 0;
 
-  Data1 = strtol(str.substr(i,8).c_str(), NULL, 16);
+  Data1 = (uint32_t) strtol(str.substr(i,8).c_str(), NULL, 16);
   i += 8;
 
   str.at(i) == '-' ? i++ : 0;
 
-  Data2 = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data2 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
   str.at(i) == '-' ? i++ : 0;
 
-  Data3 = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data3 = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
   str.at(i) == '-' ? i++ : 0;
 
-  Data4[0] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data4[0] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
   str.at(i) == '-' ? i++ : 0;
 
-  Data4[1] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data4[1] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
-  Data4[2] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data4[2] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
-  Data4[3] = strtol(str.substr(i,4).c_str(), NULL, 16);
+  Data4[3] = (uint16_t) strtol(str.substr(i,4).c_str(), NULL, 16);
   i += 4;
 
   ONE_DEBUG_MSG((" from string, dat good?\n"));

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -31,7 +31,7 @@ public:
   void parse(librevenge::RVNGInputStream *input);
 
   std::string to_string() const;
-  void from_string(std::string str);
+  void from_string(const std::string str);
 
   bool is_equal(const GUID other) const;
 

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -61,13 +61,13 @@ public:
    * @return first data sequence GUID */
   uint32_t data1() const;
   /** Getter.
-   * @ return second data sequence of GUID */
+   * @return second data sequence of GUID */
   uint16_t data2() const;
   /** Getter.
-   * @ return third data sequence of GUID */
+   * @return third data sequence of GUID */
   uint16_t data3() const;
   /** Getter.
-   * @ return forth data sequence of GUID */
+   * @return forth data sequence of GUID */
   std::array<uint16_t,4> data4() const;
 
 private:

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -18,24 +18,37 @@
 namespace libone
 {
 
+/** @brief globally unique identifier class specified by [RFC4122] or [C706] */
 class GUID
 {
 public:
+  /** Default construtor. Initializes to {00000000-0000-0000-0000-000000000000}. */
   GUID();
+
+  /** Constructor to initialize specific GUID */
   GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
        const std::array<uint16_t,4> data4);
+
+  /** Constructor to initialize specific GUID */
   GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
        const uint16_t data4_1, const uint16_t data4_2,
        const uint16_t data4_3, const uint16_t data4_4);
 
+  /** Parse GUID's content from RVNGInputStream byte stream. */
   void parse(librevenge::RVNGInputStream *input);
 
+  /** Converts GUID object to a string in this format: "{00000000-0000-0000-0000-000000000000}" */
   std::string to_string() const;
+
+  /** Parse GUID object from string.
+   * @param str - should have the format "{00000000-0000-0000-0000-000000000000}" */
   void from_string(const std::string str);
 
+  /** Checks if GUIDs are identical */
   bool is_equal(const GUID other) const;
 
 
+  /** resets GUID to {00000000-0000-0000-0000-000000000000} */
   void zero();
 
   friend librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj);
@@ -44,9 +57,17 @@ public:
   friend bool operator!=(const GUID &lhs, const GUID &rhs) noexcept;
 
 
+  /** Getter.
+   * @return first data sequence GUID */
   uint32_t data1() const;
+  /** Getter.
+   * @ return second data sequence of GUID */
   uint16_t data2() const;
+  /** Getter.
+   * @ return third data sequence of GUID */
   uint16_t data3() const;
+  /** Getter.
+   * @ return forth data sequence of GUID */
   std::array<uint16_t,4> data4() const;
 
 private:

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -34,6 +34,10 @@ public:
        const uint16_t data4_1, const uint16_t data4_2,
        const uint16_t data4_3, const uint16_t data4_4);
 
+  /** Construtor to initialize with GUID in std::string format.
+   * @sa from_string()*/
+  GUID(const std::string str);
+
   /** Parse GUID's content from RVNGInputStream byte stream. */
   void parse(librevenge::RVNGInputStream *input);
 

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -35,7 +35,7 @@ public:
        const uint16_t data4_3, const uint16_t data4_4);
 
   /** Construtor to initialize with GUID in std::string format.
-   * @sa from_string()*/
+   * @param str - should have the format "{00000000-0000-0000-0000-000000000000}" */
   GUID(const std::string str);
 
   /** Parse GUID's content from RVNGInputStream byte stream. */
@@ -44,13 +44,8 @@ public:
   /** Converts GUID object to a string in this format: "{00000000-0000-0000-0000-000000000000}" */
   std::string to_string() const;
 
-  /** Parse GUID object from string.
-   * @param str - should have the format "{00000000-0000-0000-0000-000000000000}" */
-  void from_string(const std::string str);
-
   /** Checks if GUIDs are identical */
   bool is_equal(const GUID other) const;
-
 
   /** resets GUID to {00000000-0000-0000-0000-000000000000} */
   void zero();

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <cstdint>
+#include <array>
 #include <librevenge-stream/librevenge-stream.h>
 
 namespace libone
@@ -20,15 +21,39 @@ namespace libone
 class GUID
 {
 public:
+  GUID();
+  GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
+       const std::array<uint16_t,4> data4);
+  GUID(const uint32_t data1, const uint16_t data2, const uint16_t data3,
+       const uint16_t data4_1, const uint16_t data4_2,
+       const uint16_t data4_3, const uint16_t data4_4);
+
   void parse(librevenge::RVNGInputStream *input);
-  std::string to_string();
-  bool is_equal(GUID other);
+
+  std::string to_string() const;
+  void from_string(std::string str);
+
+  bool is_equal(const GUID other) const;
+
+
+  void zero();
+
+  friend librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj);
+
+  friend bool operator==(const GUID &lhs, const GUID &rhs) noexcept;
+  friend bool operator!=(const GUID &lhs, const GUID &rhs) noexcept;
+
+
+  uint32_t data1() const;
+  uint16_t data2() const;
+  uint16_t data3() const;
+  std::array<uint16_t,4> data4() const;
+
+private:
   uint32_t Data1 = 0;
   uint16_t Data2 = 0;
   uint16_t Data3 = 0;
-  uint16_t Data4[4] = { 0 };
-  void zero();
-  void from_string(std::string str);
+  std::array<uint16_t, 4> Data4 { 0, 0, 0, 0 };
 };
 
 }

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -53,7 +53,7 @@ private:
   uint32_t Data1 = 0;
   uint16_t Data2 = 0;
   uint16_t Data3 = 0;
-  std::array<uint16_t, 4> Data4 { 0, 0, 0, 0 };
+  std::array<uint16_t, 4> Data4 {{ 0, 0, 0, 0 }};
 };
 
 }

--- a/src/lib/libone_utils.cpp
+++ b/src/lib/libone_utils.cpp
@@ -8,6 +8,8 @@
  */
 
 #include <cstdio>
+#include <sstream>
+#include <iomanip>
 
 #include "libone_utils.h"
 
@@ -231,6 +233,30 @@ unsigned long getLength(const std::shared_ptr<librevenge::RVNGInputStream> input
 {
   return getLength(input.get());
 }
+
+template <typename T>
+std::string int_to_hex(const T i)
+{
+  std::stringstream stream;
+
+  stream << std::hex
+         << std::setfill('0')
+         << std::setw(sizeof(T)*2)
+         << i;
+
+  return stream.str();
+}
+
+// instantiate for library built
+template std::string int_to_hex<uint8_t>(const uint8_t);
+template std::string int_to_hex<uint16_t>(const uint16_t);
+template std::string int_to_hex<uint32_t>(const uint32_t);
+template std::string int_to_hex<uint64_t>(const uint64_t);
+template std::string int_to_hex<int8_t>(const int8_t);
+template std::string int_to_hex<int16_t>(const int16_t);
+template std::string int_to_hex<int32_t>(const int32_t);
+template std::string int_to_hex<int64_t>(const int64_t);
+
 
 EndOfStreamException::EndOfStreamException()
 {

--- a/src/lib/libone_utils.h
+++ b/src/lib/libone_utils.h
@@ -108,6 +108,9 @@ void seekRelative(std::shared_ptr<librevenge::RVNGInputStream> input, long pos);
 
 unsigned long getLength(std::shared_ptr<librevenge::RVNGInputStream> input);
 
+template <typename T>
+std::string int_to_hex(const T i);
+
 class EndOfStreamException
 {
 public:

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -56,7 +56,7 @@ void GUIDTest::test_constructor()
 
 }
 
-void GUIDTest::test_to_string()
+void GUIDTest::test_from_string()
 {
   std::vector<std::tuple<std::string, uint32_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t> > cases {};
 
@@ -88,7 +88,7 @@ void GUIDTest::test_to_string()
   }
 }
 
-void GUIDTest::test_from_string()
+void GUIDTest::test_to_string()
 {
   std::vector<std::tuple<std::string, uint32_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t> > cases {};
 

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -129,7 +129,7 @@ void GUIDTest::test_is_equal()
 
 
   libone::GUID guid3(1,2,3,4,5,6,7);
-  libone::GUID guid4(1,2,3, {4,5,6,7});
+  libone::GUID guid4(1,2,3, {{4,5,6,7}});
 
   CPPUNIT_NS::Asserter::failIf(guid1 != guid2, "compare zerod guids 2", CPPUNIT_SOURCELINE());
 

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -1,0 +1,119 @@
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <cppunit/TestAssert.h>
+
+#include <tuple>
+
+#include "GUIDTest.h"
+#include "../../lib/GUID.h"
+
+
+CppUnit::Test *GUIDTest::suite()
+{
+  CppUnit::TestSuite *testSuite = new CppUnit::TestSuite("GUIDTest");
+
+  testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID constructor", &GUIDTest::test_constructor));
+  testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID to_string", &GUIDTest::test_to_string));
+  testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID from_string", &GUIDTest::test_from_string));
+  testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID is_equal", &GUIDTest::test_is_equal));
+
+  return testSuite;
+}
+
+
+
+void GUIDTest::setUp()
+{
+}
+
+void GUIDTest::tearDown()
+{}
+
+void GUIDTest::test_constructor()
+{
+  libone::GUID guid {};
+
+  CppUnit::Asserter::failIf(guid.data1() !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data2() !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data3() !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data4().at(0) !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data4().at(1) !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data4().at(2) !=0u, "", CPPUNIT_SOURCELINE());
+  CppUnit::Asserter::failIf(guid.data4().at(3) !=0u, "", CPPUNIT_SOURCELINE());
+
+}
+
+void GUIDTest::test_to_string()
+{
+  std::vector<std::tuple<std::string, uint32_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t> > cases {};
+
+  cases.emplace_back("{00000000-0000-0000-0000-000000000000}", 0, 0, 0, 0, 0, 0, 0);
+  cases.emplace_back("00000000-0000-0000-0000-000000000000", 0, 0, 0, 0, 0, 0,0);
+  cases.emplace_back("00000000000000000000000000000000", 0, 0, 0, 0, 0, 0, 0);
+  cases.emplace_back("{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}", 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+  cases.emplace_back("{7B5C52E4-D88C-4DA7-AEB1-5378D02996D3}", 0X7b5c52e4, 0Xd88c, 0X4da7, 0Xaeb1, 0X5378, 0Xd029, 0X96d3);
+  cases.emplace_back("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+  cases.emplace_back("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+  // failing parsing
+  cases.emplace_back("FF", 0, 0, 0, 0, 0, 0, 0);
+
+
+
+
+  for (size_t i {0}; i < cases.size(); i++)
+  {
+    auto entry = cases.at(i);
+    libone::GUID guid;
+    guid.from_string(std::get<0>(entry));
+
+    CPPUNIT_NS::assertEquals(std::get<1>(entry), guid.data1(), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data1");
+    CPPUNIT_NS::assertEquals(std::get<2>(entry), guid.data2(), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data2");
+    CPPUNIT_NS::assertEquals(std::get<3>(entry), guid.data3(), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data3");
+    CPPUNIT_NS::assertEquals(std::get<4>(entry), guid.data4().at(0), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data4[0]");
+    CPPUNIT_NS::assertEquals(std::get<5>(entry), guid.data4().at(1), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data4[1]");
+    CPPUNIT_NS::assertEquals(std::get<6>(entry), guid.data4().at(2), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data4[2]");
+    CPPUNIT_NS::assertEquals(std::get<7>(entry), guid.data4().at(3), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data4[3]");
+  }
+}
+
+void GUIDTest::test_from_string()
+{
+  std::vector<std::tuple<std::string, uint32_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t> > cases {};
+
+  cases.emplace_back("{00000000-0000-0000-0000-000000000000}", 0, 0, 0, 0, 0, 0, 0);
+  cases.emplace_back("{ffffffff-ffff-ffff-ffff-ffffffffffff}", 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+  cases.emplace_back("{7b5c52e4-d88c-4da7-aeb1-5378d02996d3}", 0X7b5c52e4, 0Xd88c, 0X4da7, 0Xaeb1, 0X5378, 0Xd029, 0X96d3);
+
+
+  for (size_t i {0}; i < cases.size(); i++)
+  {
+    auto entry = cases.at(i);
+    libone::GUID guid(
+      std::get<1>(entry),
+      std::get<2>(entry),
+      std::get<3>(entry),
+      std::get<4>(entry),
+      std::get<5>(entry),
+      std::get<6>(entry),
+      std::get<7>(entry));
+
+    CPPUNIT_NS::assertEquals(std::get<0>(entry), guid.to_string(), CPPUNIT_SOURCELINE(), "test case#" + std::to_string(i));
+  }
+
+
+}
+
+void GUIDTest::test_is_equal()
+{
+
+  libone::GUID guid1{};
+
+  libone::GUID guid2(0,0,0,0,0,0,0);
+
+
+
+  CPPUNIT_NS::Asserter::failIf(guid1 != guid2, "compare zerod guids", CPPUNIT_SOURCELINE());
+
+
+}

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -9,6 +9,9 @@
 #include "../../lib/GUID.h"
 
 
+#include <librevenge-stream/librevenge-stream.h>
+#include <librevenge/librevenge.h>
+
 CppUnit::Test *GUIDTest::suite()
 {
   CppUnit::TestSuite *testSuite = new CppUnit::TestSuite("GUIDTest");
@@ -17,6 +20,7 @@ CppUnit::Test *GUIDTest::suite()
   testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID to_string", &GUIDTest::test_to_string));
   testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID from_string", &GUIDTest::test_from_string));
   testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID is_equal", &GUIDTest::test_is_equal));
+  testSuite->addTest(new CppUnit::TestCaller<GUIDTest>("GUID parse", &GUIDTest::test_parse));
 
   return testSuite;
 }
@@ -94,7 +98,7 @@ void GUIDTest::test_to_string()
 
   cases.emplace_back("{00000000-0000-0000-0000-000000000000}", 0, 0, 0, 0, 0, 0, 0);
   cases.emplace_back("{ffffffff-ffff-ffff-ffff-ffffffffffff}", 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
-  cases.emplace_back("{7b5c52e4-d88c-4da7-aeb1-5378d02996d3}", 0X7b5c52e4, 0Xd88c, 0X4da7, 0Xaeb1, 0X5378, 0Xd029, 0X96d3);
+  cases.emplace_back("{7b5c52e4-d88c-4da7-aeb1-5378d02996d3}", 0x7b5c52e4, 0xd88c, 0x4da7, 0xaeb1, 0x5378, 0xd029, 0x96d3);
 
 
   for (size_t i {0}; i < cases.size(); i++)
@@ -132,5 +136,35 @@ void GUIDTest::test_is_equal()
 
   CPPUNIT_NS::Asserter::failIf(guid1 != guid2, "compare zerod guids 2", CPPUNIT_SOURCELINE());
 
+
+}
+
+
+
+void GUIDTest::test_parse()
+{
+  std::vector< std::tuple< std::string, std::array<unsigned char,16> > > cases {};
+
+
+
+
+  cases.emplace_back("{00000000-0000-0000-0000-000000000000}", std::array<unsigned char, 16> {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  cases.emplace_back("{ffffffff-ffff-ffff-ffff-ffffffffffff}", std::array<unsigned char, 16> {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  cases.emplace_back("{7b5c52e4-d88c-4da7-aeb1-5378d02996d3}", std::array<unsigned char, 16> {0xe4, 0x52, 0x5c, 0x7b, 0x8c, 0xd8, 0xa7, 0x4d, 0xae, 0xb1, 0x53, 0x78, 0xd0, 0x29, 0x96, 0xd3});
+
+
+  for (size_t i {0}; i < cases.size(); i++)
+  {
+    auto entry = cases.at(i);
+
+    librevenge::RVNGBinaryData bindata = librevenge::RVNGBinaryData(std::get<1>(entry).data(), std::get<1>(entry).size());
+    librevenge::RVNGInputStream *input = bindata.getDataStream();
+
+    libone::GUID guid;
+    input >> guid;
+
+    CPPUNIT_NS::assertEquals(std::get<0>(entry), guid.to_string(), CPPUNIT_SOURCELINE(), "compare parsed guid #" + std::to_string(i));
+
+  }
 
 }

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -34,13 +34,25 @@ void GUIDTest::test_constructor()
 {
   libone::GUID guid {};
 
-  CppUnit::Asserter::failIf(guid.data1() !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data2() !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data3() !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data4().at(0) !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data4().at(1) !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data4().at(2) !=0u, "", CPPUNIT_SOURCELINE());
-  CppUnit::Asserter::failIf(guid.data4().at(3) !=0u, "", CPPUNIT_SOURCELINE());
+  CPPUNIT_NS::assertEquals<uint32_t>(guid.data1(), 0, CPPUNIT_SOURCELINE(), "constructor 1, 0");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data2(), 0, CPPUNIT_SOURCELINE(), "constructor 1, 1");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data3(), 0, CPPUNIT_SOURCELINE(), "constructor 1, 2");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data4().at(0), 0, CPPUNIT_SOURCELINE(), "constructor 1, 3");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data4().at(1), 0, CPPUNIT_SOURCELINE(), "constructor 1, 4");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data4().at(2), 0, CPPUNIT_SOURCELINE(), "constructor 1, 5");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid.data4().at(3), 0, CPPUNIT_SOURCELINE(), "constructor 1, 6");
+
+
+  libone::GUID guid2(1,2,3,4,5,6,7);
+
+  CPPUNIT_NS::assertEquals<uint32_t>(guid2.data1(), 1, CPPUNIT_SOURCELINE(), "constructor 2, 0");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data2(), 2, CPPUNIT_SOURCELINE(), "constructor 2, 1");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data3(), 3, CPPUNIT_SOURCELINE(), "constructor 2, 2");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data4().at(0), 4, CPPUNIT_SOURCELINE(), "constructor 2, 3");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data4().at(1), 5, CPPUNIT_SOURCELINE(), "constructor 2, 4");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data4().at(2), 6, CPPUNIT_SOURCELINE(), "constructor 2, 5");
+  CPPUNIT_NS::assertEquals<uint16_t>(guid2.data4().at(3), 7, CPPUNIT_SOURCELINE(), "constructor 2, 6");
+
 
 }
 
@@ -114,6 +126,12 @@ void GUIDTest::test_is_equal()
 
 
   CPPUNIT_NS::Asserter::failIf(guid1 != guid2, "compare zerod guids", CPPUNIT_SOURCELINE());
+
+
+  libone::GUID guid3(1,2,3,4,5,6,7);
+  libone::GUID guid4(1,2,3, {4,5,6,7});
+
+  CPPUNIT_NS::Asserter::failIf(guid1 != guid2, "compare zerod guids 2", CPPUNIT_SOURCELINE());
 
 
 }

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -76,8 +76,7 @@ void GUIDTest::test_to_string()
   for (size_t i {0}; i < cases.size(); i++)
   {
     auto entry = cases.at(i);
-    libone::GUID guid;
-    guid.from_string(std::get<0>(entry));
+    libone::GUID guid(std::get<0>(entry));
 
     CPPUNIT_NS::assertEquals(std::get<1>(entry), guid.data1(), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data1");
     CPPUNIT_NS::assertEquals(std::get<2>(entry), guid.data2(), CPPUNIT_SOURCELINE(), "test case #" + std::to_string(i) + " data2");

--- a/src/test/common-types/GUIDTest.h
+++ b/src/test/common-types/GUIDTest.h
@@ -16,6 +16,8 @@ public:
   void test_from_string();
   void test_is_equal();
 
+  void test_parse();
+
 };
 
 #endif // GUIDTEST_H

--- a/src/test/common-types/GUIDTest.h
+++ b/src/test/common-types/GUIDTest.h
@@ -1,0 +1,21 @@
+#ifndef GUIDTEST_H
+#define GUIDTEST_H
+
+#include <cppunit/TestCase.h>
+
+class GUIDTest : public CppUnit::TestCase
+{
+public:
+  static CppUnit::Test *suite();
+
+  void setUp();
+  void tearDown();
+
+  void test_constructor();
+  void test_to_string();
+  void test_from_string();
+  void test_is_equal();
+
+};
+
+#endif // GUIDTEST_H

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -16,13 +16,22 @@ libone_test = static_library(
 )
 
 test_dep = declare_dependency(
-  dependencies : [ dependency('threads'), dependency('cppunit')],
-  # include_directories : test_incdir,
+  dependencies : [
+      dependency('threads'),
+      dependency('cppunit'),
+      librevenge_dep,
+      librevenge_generators_dep,
+      librevenge_stream_dep,
+      ],
+
+  # include_directories : test_i constncdir,
   link_with : libone_test
 )
 
 libone_test_files = [
   'test.cpp',
+  'common-types/GUIDTest.h',
+  'common-types/GUIDTest.cpp'
 ]
 
 if not meson.is_subproject()

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -17,6 +17,8 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 
+#include "common-types/GUIDTest.h"
+
 int main()
 {
   // Create the event manager and test controller
@@ -33,6 +35,7 @@ int main()
   // Add the top suite to the test runner
   CPPUNIT_NS::TestRunner runner;
   runner.addTest(CPPUNIT_NS::TestFactoryRegistry::getRegistry().makeTest());
+  runner.addTest(GUIDTest::suite());
   runner.run(controller);
 
   // output


### PR DESCRIPTION
This PR includes a number of changes:

- add convenience functions, such as `operator==` ,and `operator!=` for GUIDs
- make the Data variables private, adding getters
- make `Data4` to `std::array` for convenience, return a std::array is more explicit than c-style array (imo)
- fix `to_string()` as indicated in #13
- make `from_string()` a bit more versatile by checking presence of separators(`{`,`-`,`} `)
- add a test suite for the GUID class


I used the GUID mostly as prototype to get more familiar with cppunit. In the test routines i used `tuple` as data collector... though i have the impression this is not very elegant.