### PR TITLE
Use shared_ptr for stream passing

### DIFF
--- a/src/lib/CompactID.cpp
+++ b/src/lib/CompactID.cpp
@@ -25,6 +25,12 @@ void CompactID::parse(const libone::RVNGInputStreamPtr_t &input)
   n = temp & 0xFF;
 }
 
+const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, CompactID &obj)
+{
+  obj.parse(input);
+  return input;
+}
+
 std::string CompactID::to_string()
 {
   std::stringstream stream;

--- a/src/lib/CompactID.cpp
+++ b/src/lib/CompactID.cpp
@@ -18,7 +18,7 @@
 namespace libone
 {
 
-void CompactID::parse(librevenge::RVNGInputStream *input)
+void CompactID::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   uint32_t temp = readU32(input);
   guidIndex = (temp >> 8) & 0xFFFFFF;

--- a/src/lib/CompactID.h
+++ b/src/lib/CompactID.h
@@ -22,6 +22,8 @@ public:
   std::string to_string();
   ExtendedGUID to_EGUID();
 
+  friend const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, CompactID &obj);
+
 private:
   uint16_t n = 0;
   uint32_t guidIndex = 0; // 24 bits used only

--- a/src/lib/CompactID.h
+++ b/src/lib/CompactID.h
@@ -18,7 +18,7 @@ namespace libone
 class CompactID
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
   ExtendedGUID to_EGUID();
 

--- a/src/lib/ExtendedGUID.cpp
+++ b/src/lib/ExtendedGUID.cpp
@@ -22,6 +22,14 @@
 namespace libone
 {
 
+ExtendedGUID::ExtendedGUID() : guid(), n() {}
+
+const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, ExtendedGUID &obj)
+{
+  obj.parse(input);
+  return input;
+}
+
 void ExtendedGUID::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   guid.parse(input);

--- a/src/lib/ExtendedGUID.cpp
+++ b/src/lib/ExtendedGUID.cpp
@@ -22,7 +22,7 @@
 namespace libone
 {
 
-ExtendedGUID::ExtendedGUID() : guid(), n() {}
+ExtendedGUID::ExtendedGUID() : n(), guid() {}
 
 const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, ExtendedGUID &obj)
 {

--- a/src/lib/ExtendedGUID.cpp
+++ b/src/lib/ExtendedGUID.cpp
@@ -22,7 +22,7 @@
 namespace libone
 {
 
-void ExtendedGUID::parse(librevenge::RVNGInputStream *input)
+void ExtendedGUID::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   guid.parse(input);
 

--- a/src/lib/ExtendedGUID.h
+++ b/src/lib/ExtendedGUID.h
@@ -18,6 +18,9 @@ namespace libone
 class ExtendedGUID
 {
 public:
+  ExtendedGUID();
+
+  friend const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, ExtendedGUID &obj);
   void parse(const libone::RVNGInputStreamPtr_t &input);
   void zero();
   std::string to_string();

--- a/src/lib/ExtendedGUID.h
+++ b/src/lib/ExtendedGUID.h
@@ -18,7 +18,7 @@ namespace libone
 class ExtendedGUID
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   void zero();
   std::string to_string();
   uint32_t get_n();

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -27,7 +27,7 @@ FileChunkReference::FileChunkReference(enum FileChunkReferenceSize fcr_size) :
   m_cb(0)
 {}
 
-void FileChunkReference::parse(librevenge::RVNGInputStream *input)
+void FileChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   m_offset = input->tell();
 

--- a/src/lib/FileChunkReference.h
+++ b/src/lib/FileChunkReference.h
@@ -12,6 +12,7 @@
 
 #include <librevenge-stream/librevenge-stream.h>
 
+#include "libone_utils.h"
 namespace libone
 {
 
@@ -29,7 +30,7 @@ public:
   FileChunkReference(enum FileChunkReferenceSize fcr_size);
 
 
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
   long get_location();
   long get_size();

--- a/src/lib/FileDataStore.cpp
+++ b/src/lib/FileDataStore.cpp
@@ -19,7 +19,7 @@
 namespace libone
 {
 
-void FileDataStore::parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref)
+void FileDataStore::parse(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
 {
   FileNodeList list(ref.get_location(), ref.get_size());
   FileNode node;

--- a/src/lib/FileDataStore.h
+++ b/src/lib/FileDataStore.h
@@ -21,7 +21,7 @@ class FileDataStore
 {
 public:
 
-  void parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref);
+  void parse(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref);
   std::string to_string();
 
 

--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -91,7 +91,7 @@ std::string fnd_id_to_string(enum fnd_id id_fnd)
   return stream.str();
 }
 
-void FileNode::parse(librevenge::RVNGInputStream *input)
+void FileNode::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   m_offset = input->tell();
 
@@ -161,7 +161,7 @@ std::string FileNode::to_string()
   return stream.str();
 }
 
-void FileNode::parse_header(librevenge::RVNGInputStream *input)
+void FileNode::parse_header(const libone::RVNGInputStreamPtr_t &input)
 {
   uint32_t temp;
   enum stp_format format_stp;
@@ -203,7 +203,7 @@ void FileNode::parse_header(librevenge::RVNGInputStream *input)
   m_fnd = reference;
 }
 
-void FileNode::skip_node(librevenge::RVNGInputStream *input)
+void FileNode::skip_node(const libone::RVNGInputStreamPtr_t &input)
 {
   DBMSG << "Skipping file node by jumping over " << m_size_in_file << " bytes to " << m_offset + m_size_in_file << std::endl;
   input->seek(m_offset + m_size_in_file, librevenge::RVNG_SEEK_SET);

--- a/src/lib/FileNode.h
+++ b/src/lib/FileNode.h
@@ -13,7 +13,7 @@
 #include "FileNodeChunkReference.h"
 #include <librevenge-stream/librevenge-stream.h>
 
-
+#include "libone_utils.h"
 
 
 namespace libone
@@ -76,10 +76,10 @@ std::string fnd_id_to_string(enum fnd_id id_fnd);
 class FileNode
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
 
-  void skip_node(librevenge::RVNGInputStream *input);
+  void skip_node(const libone::RVNGInputStreamPtr_t &input);
 
   enum fnd_id get_FileNodeID()
   {
@@ -109,7 +109,7 @@ private:
   uint32_t m_header_size = 0;
   enum fnd_id m_fnd_id = fnd_invalid_id;
   enum fnd_basetype m_base_type = fnd_invalid_basetype;
-  void parse_header(librevenge::RVNGInputStream *input);
+  void parse_header(const libone::RVNGInputStreamPtr_t &input);
   FileNodeChunkReference m_fnd = FileNodeChunkReference(stp_invalid, cb_invalid, 0);
 
   static const uint32_t mask_fnd_id        = 0x3FF;
@@ -125,6 +125,8 @@ private:
 };
 
 
-}
+} // namespace libone
 
-#endif
+#endif //INCLUDED_LIBONE_FILENODE_H
+
+/* vim:set shiftwidth=2 softtabstop=2 expandtab: */

--- a/src/lib/FileNodeChunkReference.cpp
+++ b/src/lib/FileNodeChunkReference.cpp
@@ -102,7 +102,7 @@ uint32_t FileNodeChunkReference::get_size_in_file()
   return ret;
 }
 
-void FileNodeChunkReference::parse(librevenge::RVNGInputStream *input)
+void FileNodeChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   input->seek(m_offset, librevenge::RVNG_SEEK_SET);
 

--- a/src/lib/FileNodeChunkReference.h
+++ b/src/lib/FileNodeChunkReference.h
@@ -12,6 +12,8 @@
 
 #include <librevenge-stream/librevenge-stream.h>
 
+#include "libone_utils.h"
+
 namespace libone
 {
 
@@ -42,7 +44,7 @@ public:
   uint64_t get_location();
   uint64_t get_size();
   uint32_t get_size_in_file();
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   void set_zero();
   enum stp_format get_stp_fmt()
   {

--- a/src/lib/FileNodeList.cpp
+++ b/src/lib/FileNodeList.cpp
@@ -29,7 +29,7 @@ FileNodeList::FileNodeList(uint64_t new_location, uint64_t new_size) :
   m_fragment_list(std::vector<FileNodeListFragment>())
 {}
 
-void FileNodeList::parse(librevenge::RVNGInputStream *input)
+void FileNodeList::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   input->seek(m_offset, librevenge::RVNG_SEEK_SET);
 

--- a/src/lib/FileNodeList.h
+++ b/src/lib/FileNodeList.h
@@ -17,6 +17,8 @@
 #include "FileNode.h"
 #include "FileNodeListFragment.h"
 
+#include "libone_utils.h"
+
 namespace libone
 {
 
@@ -24,7 +26,7 @@ class FileNodeList
 {
 public:
   FileNodeList(uint64_t new_location, uint64_t new_size);
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   bool is_end();
   std::string to_string();
 

--- a/src/lib/FileNodeListFragment.cpp
+++ b/src/lib/FileNodeListFragment.cpp
@@ -35,13 +35,14 @@ FileNodeListFragment::FileNodeListFragment(uint64_t location, uint64_t size) :
   DBMSG << "location " << m_offset << " size " << m_size << " field_size_footer " << field_size_footer << " field_size_next_fragment " << field_size_next_fragment << std::endl;
 }
 
-void FileNodeListFragment::parse(librevenge::RVNGInputStream *input)
+void FileNodeListFragment::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   uint64_t magic;
   DBMSG << "input@" << input->tell() << ", beginning" << std::endl;
 
   magic = readU64(input, false);
-  if (magic != header_magic_id) {
+  if (magic != header_magic_id)
+  {
     DBMSG << "Parsed magic " << magic << " does not match expected header magic" << header_magic_id << std::endl;
     assert(false);
   }
@@ -74,7 +75,8 @@ void FileNodeListFragment::parse(librevenge::RVNGInputStream *input)
   DBMSG << "Parsed next fragment, got " << m_next_fragment.to_string() << std::endl;
 
   magic = readU64(input, false);
-  if (magic != footer_magic_id) {
+  if (magic != footer_magic_id)
+  {
     DBMSG << "Parsed magic " << magic << " does not match expected footer magic" << footer_magic_id << std::endl;
     assert(false);
   }
@@ -82,7 +84,7 @@ void FileNodeListFragment::parse(librevenge::RVNGInputStream *input)
   return;
 }
 
-void FileNodeListFragment::skip_padding(librevenge::RVNGInputStream *input)
+void FileNodeListFragment::skip_padding(const libone::RVNGInputStreamPtr_t &input)
 {
   int i;
   for (i=0;; i++)

--- a/src/lib/FileNodeListFragment.h
+++ b/src/lib/FileNodeListFragment.h
@@ -17,6 +17,8 @@
 #include "FileChunkReference.h"
 #include "FileNode.h"
 
+#include "libone_utils.h"
+
 namespace libone
 {
 
@@ -24,7 +26,7 @@ class FileNodeListFragment
 {
 public:
   FileNodeListFragment(uint64_t location, uint64_t size);
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
   uint32_t get_list_id()
   {
@@ -60,7 +62,7 @@ private:
   FileChunkReference m_next_fragment;
 
   bool is_end_of_list(FileNode current_node, long current_offset);
-  void skip_padding(librevenge::RVNGInputStream *input);
+  void skip_padding(const libone::RVNGInputStreamPtr_t &input);
 
   const uint64_t header_magic_id = 0xA4567AB1F5F7F4C4;
   const uint64_t footer_magic_id = 0x8BC215C38233BA4B;

--- a/src/lib/GUID.cpp
+++ b/src/lib/GUID.cpp
@@ -124,7 +124,7 @@ void GUID::zero()
   }
 }
 
-void GUID::parse(librevenge::RVNGInputStream *input)
+void GUID::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   Data1 = readU32(input, false);
   Data2 = readU16(input, false);
@@ -167,7 +167,7 @@ bool GUID::is_equal(const GUID other) const
   return false;
 }
 
-librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj)
+const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, GUID &obj)
 {
   obj.parse(input);
   return input;

--- a/src/lib/GUID.h
+++ b/src/lib/GUID.h
@@ -15,6 +15,8 @@
 #include <array>
 #include <librevenge-stream/librevenge-stream.h>
 
+#include "libone_utils.h"
+
 namespace libone
 {
 
@@ -39,7 +41,7 @@ public:
   GUID(const std::string str);
 
   /** Parse GUID's content from RVNGInputStream byte stream. */
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
 
   /** Converts GUID object to a string in this format: "{00000000-0000-0000-0000-000000000000}" */
   std::string to_string() const;
@@ -50,7 +52,7 @@ public:
   /** resets GUID to {00000000-0000-0000-0000-000000000000} */
   void zero();
 
-  friend librevenge::RVNGInputStream *operator>>(librevenge::RVNGInputStream *input, GUID &obj);
+  friend const libone::RVNGInputStreamPtr_t &operator>>(const libone::RVNGInputStreamPtr_t &input, GUID &obj);
 
   friend bool operator==(const GUID &lhs, const GUID &rhs) noexcept;
   friend bool operator!=(const GUID &lhs, const GUID &rhs) noexcept;

--- a/src/lib/Header.cpp
+++ b/src/lib/Header.cpp
@@ -25,7 +25,7 @@
 namespace libone
 {
 
-void Header::parse(librevenge::RVNGInputStream *input)
+void Header::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   input->seek(OFFSET_HEADER, librevenge::RVNG_SEEK_SET);
 

--- a/src/lib/Header.h
+++ b/src/lib/Header.h
@@ -21,7 +21,7 @@ namespace libone
 class Header
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   GUID guidFileType = GUID();
   GUID guidFile = GUID();
   GUID guidLegacyFileVersion = GUID();

--- a/src/lib/ONEDocument.cpp
+++ b/src/lib/ONEDocument.cpp
@@ -70,8 +70,9 @@ ONEAPI ONEDocument::Result ONEDocument::parse(librevenge::RVNGInputStream *const
 
 ONEAPI ONEDocument::Result ONEDocument::parse(librevenge::RVNGInputStream *const input, librevenge::RVNGDrawingInterface *const document, const ONEDocument::Type type, const char *const) try
 {
-  Header header;
-  header.parse(input);
+  /// \todo parsing the header doesn't seem to do anything here, also needs shared_ptr now
+//  Header header;
+//  header.parse(input);
 
   (void) document;
   // sanity check
@@ -82,7 +83,7 @@ ONEAPI ONEDocument::Result ONEDocument::parse(librevenge::RVNGInputStream *const
 
   const RVNGInputStreamPtr_t input_(input, ONEDummyDeleter());
 
-  OneNoteParser parser = OneNoteParser(input, document);
+  OneNoteParser parser = OneNoteParser(input_, document);
   (void) parser;
   return RESULT_UNKNOWN_ERROR;
 }

--- a/src/lib/Object.cpp
+++ b/src/lib/Object.cpp
@@ -94,7 +94,7 @@ void Object::to_document(librevenge::RVNGDrawingInterface *document, std::unorde
   }
 }
 
-void Object::parse_list(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
+void Object::parse_list(const libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
 {
   ObjectSpaceStreamOfOIDs oids = ObjectSpaceStreamOfOIDs(guid);
   ObjectSpaceStreamOfOSIDs osids = ObjectSpaceStreamOfOSIDs();

--- a/src/lib/Object.cpp
+++ b/src/lib/Object.cpp
@@ -17,7 +17,7 @@
 namespace libone
 {
 
-Object::Object(librevenge::RVNGInputStream *input, struct object_header _header)
+Object::Object(const libone::RVNGInputStreamPtr_t &input, struct object_header _header)
 {
   guid = _header.guid;
   jcid = _header.jcid;
@@ -94,7 +94,7 @@ void Object::to_document(librevenge::RVNGDrawingInterface *document, std::unorde
   }
 }
 
-void Object::parse_list(librevenge::RVNGInputStream *input, FileNodeChunkReference ref)
+void Object::parse_list(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
 {
   ObjectSpaceStreamOfOIDs oids = ObjectSpaceStreamOfOIDs(guid);
   ObjectSpaceStreamOfOSIDs osids = ObjectSpaceStreamOfOSIDs();

--- a/src/lib/Object.h
+++ b/src/lib/Object.h
@@ -38,7 +38,7 @@ class Object
 {
 
 public:
-  Object(librevenge::RVNGInputStream *input, struct object_header _header);
+  Object(const libone::RVNGInputStreamPtr_t &input, struct object_header _header);
   bool get_read_only();
   void set_read_only(bool new_);
   ExtendedGUID get_guid();
@@ -46,7 +46,7 @@ public:
   void to_document(librevenge::RVNGDrawingInterface *document, std::unordered_map<std::string, Object> objects);
 
 protected:
-  void parse_list(librevenge::RVNGInputStream *input, FileNodeChunkReference ref);
+  void parse_list(const libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref);
 
 private:
   FileNodeChunkReference body = FileNodeChunkReference(stp_format::stp_invalid, cb_format::cb_invalid, 0);

--- a/src/lib/ObjectGroup.cpp
+++ b/src/lib/ObjectGroup.cpp
@@ -13,7 +13,7 @@
 namespace libone
 {
 
-std::unordered_map<std::string, libone::Object> ObjectGroup::list_parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref)
+std::unordered_map<std::string, libone::Object> ObjectGroup::list_parse(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
 {
   FileNodeList list(ref.get_location(), ref.get_size());
   std::unordered_map<std::string, libone::Object> object_map = std::unordered_map<std::string, libone::Object>();

--- a/src/lib/ObjectGroup.h
+++ b/src/lib/ObjectGroup.h
@@ -26,7 +26,7 @@ namespace libone
 class ObjectGroup
 {
 public:
-  std::unordered_map<std::string, libone::Object> list_parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref);
+  std::unordered_map<std::string, libone::Object> list_parse(libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref);
   std::string get_guid();
 
 private:

--- a/src/lib/ObjectSpace.cpp
+++ b/src/lib/ObjectSpace.cpp
@@ -18,7 +18,7 @@ ObjectSpace::ObjectSpace()
 {
 }
 
-void ObjectSpace::parse(librevenge::RVNGInputStream *input, FileNode &node)
+void ObjectSpace::parse(const libone::RVNGInputStreamPtr_t &input, FileNode &node)
 {
   m_fnd_list_ref = node.get_fnd();
 
@@ -35,7 +35,7 @@ void ObjectSpace::parse(librevenge::RVNGInputStream *input, FileNode &node)
 
 }
 
-void ObjectSpace::list_parse(librevenge::RVNGInputStream *input, ExtendedGUID expected_guid, FileNodeChunkReference ref)
+void ObjectSpace::list_parse(const libone::RVNGInputStreamPtr_t &input, ExtendedGUID expected_guid, FileNodeChunkReference ref)
 {
   Revision rev;
   FileNode node;

--- a/src/lib/ObjectSpace.h
+++ b/src/lib/ObjectSpace.h
@@ -26,8 +26,8 @@ class ObjectSpace
 {
 public:
   ObjectSpace();
-  void parse(librevenge::RVNGInputStream *input, FileNode &node);
-  void list_parse(librevenge::RVNGInputStream *input, ExtendedGUID guid, FileNodeChunkReference ref); // Assume we're at the beginning of a FileNode list
+  void parse(const libone::RVNGInputStreamPtr_t &input, FileNode &node);
+  void list_parse(const libone::RVNGInputStreamPtr_t &input, ExtendedGUID guid, FileNodeChunkReference ref); // Assume we're at the beginning of a FileNode list
 //    std::unordered_map<std::string, libone::Object> ObjectMap = std::unordered_map<std::string, libone::Object>();
   std::unordered_map<std::string, libone::Revision> RevisionMap = std::unordered_map<std::string, libone::Revision>();
   void to_document(librevenge::RVNGDrawingInterface *document);

--- a/src/lib/ObjectSpaceStreams.cpp
+++ b/src/lib/ObjectSpaceStreams.cpp
@@ -23,7 +23,7 @@
 namespace libone
 {
 
-void ObjectSpaceStream::parse_header(librevenge::RVNGInputStream *input)
+void ObjectSpaceStream::parse_header(const libone::RVNGInputStreamPtr_t &input)
 {
   uint32_t temp = readU32(input);
   std::bitset<32> x(temp);
@@ -51,7 +51,7 @@ uint16_t ObjectSpaceStream::get_B()
   return b;
 }
 
-std::vector<ExtendedGUID> ObjectSpaceStreamOfOIDs::parse(librevenge::RVNGInputStream *input)
+std::vector<ExtendedGUID> ObjectSpaceStreamOfOIDs::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   std::vector<ExtendedGUID> ret = std::vector<ExtendedGUID>();
   parse_header(input);
@@ -73,7 +73,7 @@ std::vector<ExtendedGUID> ObjectSpaceStreamOfOIDs::parse(librevenge::RVNGInputSt
   return ret;
 }
 
-std::vector<ExtendedGUID> ObjectSpaceStreamOfOSIDs::parse(librevenge::RVNGInputStream *input)
+std::vector<ExtendedGUID> ObjectSpaceStreamOfOSIDs::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   std::vector<ExtendedGUID> ret = std::vector<ExtendedGUID>();
   parse_header(input);
@@ -86,7 +86,7 @@ std::vector<ExtendedGUID> ObjectSpaceStreamOfOSIDs::parse(librevenge::RVNGInputS
   return ret;
 }
 
-std::vector<ExtendedGUID> ObjectSpaceStreamOfContextIDs::parse(librevenge::RVNGInputStream *input)
+std::vector<ExtendedGUID> ObjectSpaceStreamOfContextIDs::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   std::vector<ExtendedGUID> ret = std::vector<ExtendedGUID>();
   parse_header(input);

--- a/src/lib/ObjectSpaceStreams.h
+++ b/src/lib/ObjectSpaceStreams.h
@@ -25,14 +25,14 @@ class ObjectSpaceStream
 {
 public:
 
-  void parse_header(librevenge::RVNGInputStream *input);
+  void parse_header(const libone::RVNGInputStreamPtr_t &input);
   std::string header_string();
   virtual ~ObjectSpaceStream() { };
   uint16_t get_A();
   uint16_t get_B();
   uint32_t get_Count();
 
-  virtual std::vector<ExtendedGUID> parse(librevenge::RVNGInputStream *input) = 0;
+  virtual std::vector<ExtendedGUID> parse(const libone::RVNGInputStreamPtr_t &input) = 0;
 protected:
   uint32_t Count = 0;
   uint16_t a = 0;
@@ -46,7 +46,7 @@ public:
   {
     guid = new_guid;
   }
-  std::vector<ExtendedGUID> parse(librevenge::RVNGInputStream *input);
+  std::vector<ExtendedGUID> parse(const libone::RVNGInputStreamPtr_t &input);
 private:
   ExtendedGUID guid = ExtendedGUID();
 };
@@ -54,14 +54,14 @@ private:
 class ObjectSpaceStreamOfOSIDs: public ObjectSpaceStream
 {
 public:
-  std::vector<ExtendedGUID>  parse(librevenge::RVNGInputStream *input);
+  std::vector<ExtendedGUID>  parse(const libone::RVNGInputStreamPtr_t &input);
 private:
 };
 
 class ObjectSpaceStreamOfContextIDs: public ObjectSpaceStream
 {
 public:
-  std::vector<ExtendedGUID>  parse(librevenge::RVNGInputStream *input);
+  std::vector<ExtendedGUID>  parse(const libone::RVNGInputStreamPtr_t &input);
 private:
 };
 

--- a/src/lib/OneNoteParser.cpp
+++ b/src/lib/OneNoteParser.cpp
@@ -20,7 +20,7 @@ namespace libone
 
 libone::ExtendedGUID DataSignatureGroup = libone::ExtendedGUID();
 
-OneNoteParser::OneNoteParser(librevenge::RVNGInputStream *input, librevenge::RVNGDrawingInterface *const document)
+OneNoteParser::OneNoteParser(const libone::RVNGInputStreamPtr_t &input, librevenge::RVNGDrawingInterface *const document)
 {
   Header header = Header();
   libone::ExtendedGUID RootObject;
@@ -52,7 +52,7 @@ OneNoteParser::OneNoteParser(librevenge::RVNGInputStream *input, librevenge::RVN
 
 }
 
-void OneNoteParser::parse_transactions(librevenge::RVNGInputStream *input, Header &header)
+void OneNoteParser::parse_transactions(const libone::RVNGInputStreamPtr_t &input, Header &header)
 {
   TransactionLog log = TransactionLog(header.fcrTransactionLog.get_location(),
                                       header.fcrTransactionLog.get_size(),
@@ -60,7 +60,7 @@ void OneNoteParser::parse_transactions(librevenge::RVNGInputStream *input, Heade
   log.parse(input);
 }
 
-void OneNoteParser::parse_root_file_node_list(librevenge::RVNGInputStream *input,
+void OneNoteParser::parse_root_file_node_list(const libone::RVNGInputStreamPtr_t &input,
                                               Header &header, ExtendedGUID &root_object)
 {
   ExtendedGUID guid;

--- a/src/lib/OneNoteParser.h
+++ b/src/lib/OneNoteParser.h
@@ -28,14 +28,14 @@ namespace libone
 class OneNoteParser
 {
 public:
-  OneNoteParser(librevenge::RVNGInputStream *input, librevenge::RVNGDrawingInterface *const document);
+  OneNoteParser(const libone::RVNGInputStreamPtr_t &input, librevenge::RVNGDrawingInterface *const document);
 
 private:
   std::unordered_map<std::string, libone::ObjectSpace> ObjectSpaces = std::unordered_map<std::string, libone::ObjectSpace>();
 
-  void parse_root_file_node_list(librevenge::RVNGInputStream *input,
+  void parse_root_file_node_list(const libone::RVNGInputStreamPtr_t &input,
                                  Header &header, ExtendedGUID &root_object);
-  void parse_transactions(librevenge::RVNGInputStream *input, Header &header);
+  void parse_transactions(const libone::RVNGInputStreamPtr_t &input, Header &header);
 };
 
 

--- a/src/lib/PageMetaData.cpp
+++ b/src/lib/PageMetaData.cpp
@@ -12,7 +12,7 @@
 namespace libone
 {
 
-PageMetaData::PageMetaData(librevenge::RVNGInputStream *input, struct object_header _header) : Object(input, _header)
+PageMetaData::PageMetaData(const libone::RVNGInputStreamPtr_t &input, struct object_header _header) : Object(input, _header)
 {
 //    Object(_header);
   (void) input;

--- a/src/lib/PageMetaData.h
+++ b/src/lib/PageMetaData.h
@@ -20,7 +20,7 @@ namespace libone
 class PageMetaData: public Object
 {
 public:
-  PageMetaData(librevenge::RVNGInputStream *input, struct object_header _header);
+  PageMetaData(const libone::RVNGInputStreamPtr_t &input, struct object_header _header);
 };
 
 

--- a/src/lib/Property.h
+++ b/src/lib/Property.h
@@ -21,7 +21,7 @@ namespace libone
 class PropertyValue
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
 private:
   uint16_t count = 0;

--- a/src/lib/PropertySet.cpp
+++ b/src/lib/PropertySet.cpp
@@ -18,7 +18,7 @@
 namespace libone
 {
 
-void PropertySet::parse(librevenge::RVNGInputStream *input)
+void PropertySet::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   bool unknown = false;
   count = readU16(input);

--- a/src/lib/PropertySet.h
+++ b/src/lib/PropertySet.h
@@ -22,7 +22,7 @@ namespace libone
 class PropertySet
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
 private:
   uint16_t count = 0;

--- a/src/lib/PropertyValue.h
+++ b/src/lib/PropertyValue.h
@@ -18,10 +18,11 @@
 namespace libone
 {
 
+/// \todo duplicate code and missing implementation, see also Property.h
 class Property
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
 private:
   uint16_t count = 0;

--- a/src/lib/Revision.cpp
+++ b/src/lib/Revision.cpp
@@ -19,7 +19,7 @@
 namespace libone
 {
 
-void Revision::list_parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref)
+void Revision::list_parse(const libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref)
 {
   FileNodeList list(ref.get_location(), ref.get_size());
   FileNode node;
@@ -46,7 +46,7 @@ std::string Revision::to_string()
   return stream.str();
 }
 
-void Revision::parse_dependencies(librevenge::RVNGInputStream *input, FileNode node)
+void Revision::parse_dependencies(const libone::RVNGInputStreamPtr_t &input, FileNode node)
 {
   CompactID temp;
   uint32_t n_8bitoverrides;

--- a/src/lib/Revision.h
+++ b/src/lib/Revision.h
@@ -17,13 +17,14 @@
 #include "Object.h"
 #include "ObjectGroup.h"
 
+
 namespace libone
 {
 
 class Revision
 {
 public:
-  void list_parse(librevenge::RVNGInputStream *input, FileNodeChunkReference ref);
+  void list_parse(const libone::RVNGInputStreamPtr_t &input, FileNodeChunkReference ref);
   std::string get_guid();
   std::string to_string();
   ObjectGroup group = ObjectGroup();
@@ -39,7 +40,7 @@ private:
   uint32_t role = 0;
   uint16_t odcsDefault = 0;
   ExtendedGUID context = ExtendedGUID();
-  void parse_dependencies(librevenge::RVNGInputStream *input, FileNode node);
+  void parse_dependencies(const libone::RVNGInputStreamPtr_t &input, FileNode node);
 
 };
 

--- a/src/lib/StringInStorageBuffer.cpp
+++ b/src/lib/StringInStorageBuffer.cpp
@@ -19,7 +19,7 @@
 namespace libone
 {
 
-void StringInStorageBuffer::parse(librevenge::RVNGInputStream *input)
+void StringInStorageBuffer::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   std::stringstream stream;
   length = readU32(input);

--- a/src/lib/StringInStorageBuffer.h
+++ b/src/lib/StringInStorageBuffer.h
@@ -15,6 +15,8 @@
 #include <librevenge/librevenge.h>
 #include <vector>
 
+#include "libone_utils.h"
+
 namespace libone
 {
 

--- a/src/lib/StringInStorageBuffer.h
+++ b/src/lib/StringInStorageBuffer.h
@@ -21,7 +21,7 @@ namespace libone
 class StringInStorageBuffer
 {
 public:
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   uint32_t length = 0;
   std::string to_string();
 

--- a/src/lib/TransactionEntry.cpp
+++ b/src/lib/TransactionEntry.cpp
@@ -21,7 +21,7 @@ TransactionEntry::TransactionEntry() :
   m_crc(0)
 {}
 
-void TransactionEntry::parse(librevenge::RVNGInputStream *input)
+void TransactionEntry::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   m_offset = input->tell();
   while (true)

--- a/src/lib/TransactionEntry.h
+++ b/src/lib/TransactionEntry.h
@@ -29,7 +29,7 @@ class TransactionEntry
 {
 public:
   TransactionEntry();
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
   std::vector<struct fnd_list_change> get_changes()
   {

--- a/src/lib/TransactionLog.cpp
+++ b/src/lib/TransactionLog.cpp
@@ -28,7 +28,7 @@ TransactionLog::TransactionLog(uint64_t location, uint32_t size, uint32_t max_tr
 }
 
 
-void TransactionLog::parse(librevenge::RVNGInputStream *input)
+void TransactionLog::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   TransactionLogFragment fragment = TransactionLogFragment();
   uint64_t location = m_offset;

--- a/src/lib/TransactionLog.h
+++ b/src/lib/TransactionLog.h
@@ -20,7 +20,7 @@ class TransactionLog
 {
 public:
   TransactionLog(uint64_t location, uint32_t size, uint32_t max_transactions);
-  void parse(librevenge::RVNGInputStream *input);
+  void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string();
   uint32_t get_srcID();
   uint32_t get_Switch();

--- a/src/lib/TransactionLogFragment.cpp
+++ b/src/lib/TransactionLogFragment.cpp
@@ -27,7 +27,7 @@ TransactionLogFragment::TransactionLogFragment() :
 {}
 
 
-int TransactionLogFragment::parse(librevenge::RVNGInputStream *input,
+int TransactionLogFragment::parse(const libone::RVNGInputStreamPtr_t &input,
                                   uint64_t location, uint32_t size,
                                   uint32_t transactions_to_parse)
 {

--- a/src/lib/TransactionLogFragment.h
+++ b/src/lib/TransactionLogFragment.h
@@ -20,7 +20,8 @@ class TransactionLogFragment
 {
 public:
   TransactionLogFragment();
-  int parse(librevenge::RVNGInputStream *input,
+  /// \todo use FileChunkReference in parse
+  int parse(const libone::RVNGInputStreamPtr_t &input,
             uint64_t location, uint32_t size,
             uint32_t transactions_to_parse);
   std::string to_string();

--- a/src/test/common-types/GUIDTest.cpp
+++ b/src/test/common-types/GUIDTest.cpp
@@ -158,7 +158,7 @@ void GUIDTest::test_parse()
     auto entry = cases.at(i);
 
     librevenge::RVNGBinaryData bindata = librevenge::RVNGBinaryData(std::get<1>(entry).data(), std::get<1>(entry).size());
-    librevenge::RVNGInputStream *input = bindata.getDataStream();
+    libone::RVNGInputStreamPtr_t input(bindata.getDataStream());
 
     libone::GUID guid;
     input >> guid;


### PR DESCRIPTION
in `libone_util.h`, there is a typedef for `std::shared_ptr<librevenge::RVNGInputStream>` by default.

I also wasn't very confident about a submission regarding the operator overloading for the `GUID`. As far as i know, it's recommended to passes only references in overloaded operators. Passing pointers there seems to open up possibilities for memory leaks...

I also read in some readme file regarding librevenge that it is suggested to use smart pointers and avoid raw pointers.

With this PR, most occurrences of `librevenge::RVNGInputStream *input` have been replaced with the drop-in `const libone::RVNGInputStreamPtr_t &input` aka `const std::shared_ptr<librevenge::RVNGInputStream> &input`.


Although, smart pointers are often recommended, the current implementations are rather save in using raw points. So this PR somewhat reflects my subjective opinion on coding style.
