### PR TITLE
FileNode: Make FileNodeID an enum class

### DIFF
--- a/src/lib/FileNode.cpp
+++ b/src/lib/FileNode.cpp
@@ -23,69 +23,69 @@
 namespace libone
 {
 
-std::string fnd_id_to_string(enum fnd_id id_fnd)
+std::string fnd_id_to_string(FndId id_fnd)
 {
   std::stringstream stream;
 
   switch (id_fnd)
   {
-  case fnd_id::ObjectSpaceManifestListStartFND:
+  case FndId::ObjectSpaceManifestListStartFND:
     stream << "ObjectSpaceManifestListStartFND";
     break;
-  case fnd_id::ChunkTerminatorFND:
+  case FndId::ChunkTerminatorFND:
     stream << "ChunkTerminatorFND";
     break;
-  case fnd_id::RevisionManifestListStartFND:
+  case FndId::RevisionManifestListStartFND:
     stream << "RevisionManifestListStart";
     break;
-  case fnd_id::RevisionManifestStart4FND:
+  case FndId::RevisionManifestStart4FND:
     stream << "RevisionManifestStart4FND";
     break;
-  case fnd_id::RevisionManifestStart6FND:
+  case FndId::RevisionManifestStart6FND:
     stream << "RevisionManifestStart6FND";
     break;
-  case fnd_id::RevisionManifestStart7FND:
+  case FndId::RevisionManifestStart7FND:
     stream << "RevisionManifestStart";
     break;
-  case fnd_id::RevisionManifestListReferenceFND:
+  case FndId::RevisionManifestListReferenceFND:
     stream << "RevisionManifestListReferenceFND";
     break;
-  case fnd_id::ObjectGroupListReferenceFND:
+  case FndId::ObjectGroupListReferenceFND:
     stream << "ObjectGroupListReferenceFND";
     break;
-  case fnd_id::ObjectSpaceManifestListReferenceFND:
+  case FndId::ObjectSpaceManifestListReferenceFND:
     stream << "ObjectSpaceManifestListReferenceFND";
     break;
-  case fnd_id::ObjectSpaceManifestRootFND:
+  case FndId::ObjectSpaceManifestRootFND:
     stream << "ObjectSpaceManifestListRootFND";
     break;
-  case fnd_id::FileDataStoreListReferenceFND:
+  case FndId::FileDataStoreListReferenceFND:
     stream << "FileDataStoreListReferenceFND";
     break;
-  case fnd_id::ObjectGroupStartFND:
+  case FndId::ObjectGroupStartFND:
     stream << "ObjectGroupStartFND";
     break;
-  case fnd_id::GlobalIdTableStart2FND:
+  case FndId::GlobalIdTableStart2FND:
     stream << "GlobalIdTableStart2FND";
     break;
-  case fnd_id::GlobalIdTableEntryFNDX:
+  case FndId::GlobalIdTableEntryFNDX:
     stream << "GlobalIdTableEntryFNDX";
     break;
-  case fnd_id::GlobalIdTableEndFNDX:
+  case FndId::GlobalIdTableEndFNDX:
     stream << "GlobalIdTableEndFNDX";
     break;
-  case fnd_id::DataSignatureGroupDefinitionFND:
+  case FndId::DataSignatureGroupDefinitionFND:
     stream << "DataSignatureGroupDefinitionFND";
     break;
-  case fnd_id::ObjectDeclaration2RefCountFND:
+  case FndId::ObjectDeclaration2RefCountFND:
     stream << "ObjectDeclaration2RefCountFND";
     break;
-  case fnd_id::ObjectGroupEndFND:
+  case FndId::ObjectGroupEndFND:
     stream << "ObjectGroupEndFND";
     break;
-  case fnd_id::fnd_invalid_id:
+  case FndId::fnd_invalid_id:
   default:
-    stream << "dunno but value is " << id_fnd;
+    stream << "Invalid FND";
     break;
   }
   return stream.str();
@@ -95,38 +95,89 @@ void FileNode::parse(const libone::RVNGInputStreamPtr_t &input)
 {
   m_offset = input->tell();
 
-  DBMSG << "Will parse at " << m_offset << std::endl;
-
   parse_header(input);
+
   switch (m_fnd_id)
   {
-  case fnd_id::ObjectSpaceManifestListStartFND:
-  case fnd_id::RevisionManifestListStartFND:
-  case fnd_id::RevisionManifestStart4FND:
-  case fnd_id::RevisionManifestStart6FND:
-  case fnd_id::RevisionManifestStart7FND:
-  case fnd_id::RevisionManifestListReferenceFND:
-  case fnd_id::ObjectGroupListReferenceFND:
-  case fnd_id::ObjectSpaceManifestListReferenceFND:
-  case fnd_id::ObjectSpaceManifestRootFND:
-  case fnd_id::FileDataStoreListReferenceFND:
-  case fnd_id::ObjectGroupStartFND:
-  case fnd_id::GlobalIdTableStart2FND:
-  case fnd_id::GlobalIdTableEntryFNDX:
-  case fnd_id::GlobalIdTableEndFNDX:
-  case fnd_id::DataSignatureGroupDefinitionFND:
-  case fnd_id::ObjectDeclaration2RefCountFND:
-  case fnd_id::ObjectGroupEndFND:
-  case fnd_id::ObjectInfoDependencyOverridesFND:
-  case fnd_id::RootObjectReference3FND:
-  case fnd_id::RevisionManifestEndFND:
-  case fnd_id::ObjectDeclarationFileData3RefCountFND:
-  case fnd_id::ReadOnlyObjectDeclaration2RefCountFND:
-  case fnd_id::FileDataStoreObjectReferenceFND:
     break;
-  case fnd_id::fnd_invalid_id:
+  case FndId::DataSignatureGroupDefinitionFND:
+    break;
+  case FndId::FileDataStoreListReferenceFND:
+    break;
+  case FndId::FileDataStoreObjectReferenceFND:
+    break;
+  case FndId::GlobalIdTableEntry2FNDX:
+    break;
+  case FndId::GlobalIdTableEntry3FNDX:
+    break;
+  case FndId::GlobalIdTableEntryFNDX:
+    break;
+  case FndId::GlobalIdTableStartFNDX:
+    break;
+  case FndId::HashedChunkDescriptor2FND:
+    break;
+  case FndId::ObjectDataEncryptionKeyV2FNDX:
+    break;
+  case FndId::ObjectDeclaration2LargeRefCountFND:
+    break;
+  case FndId::ObjectDeclaration2RefCountFND:
+    break;
+  case FndId::ObjectDeclarationFileData3LargeRefCountFND:
+    break;
+  case FndId::ObjectDeclarationFileData3RefCountFND:
+    break;
+  case FndId::ObjectDeclarationWithRefCount2FNDX:
+    break;
+  case FndId::ObjectDeclarationWithRefCountFNDX:
+    break;
+  case FndId::ObjectGroupListReferenceFND:
+    break;
+  case FndId::ObjectGroupStartFND:
+    break;
+  case FndId::ObjectInfoDependencyOverridesFND:
+    break;
+  case FndId::ObjectRevisionWithRefCount2FNDX:
+    break;
+  case FndId::ObjectRevisionWithRefCountFNDX:
+    break;
+  case FndId::ObjectSpaceManifestListReferenceFND:
+    break;
+  case FndId::ObjectSpaceManifestListStartFND:
+    break;
+  case FndId::ObjectSpaceManifestRootFND:
+    break;
+  case FndId::ReadOnlyObjectDeclaration2LargeRefCountFND:
+    break;
+  case FndId::ReadOnlyObjectDeclaration2RefCountFND:
+    break;
+  case FndId::RevisionManifestListReferenceFND:
+    break;
+  case FndId::RevisionManifestListStartFND:
+    break;
+  case FndId::RevisionManifestStart4FND:
+    break;
+  case FndId::RevisionManifestStart6FND:
+    break;
+  case FndId::RevisionManifestStart7FND:
+    break;
+  case FndId::RevisionRoleAndContextDeclarationFND:
+    break;
+  case FndId::RevisionRoleDeclarationFND:
+    break;
+  case FndId::RootObjectReference2FNDX:
+    break;
+  case FndId::RootObjectReference3FND:
+    break;
+
+  // nodes without data
+  case FndId::RevisionManifestEndFND:
+  case FndId::GlobalIdTableStart2FND:
+  case FndId::GlobalIdTableEndFNDX:
+  case FndId::ObjectGroupEndFND:
+  case FndId::ChunkTerminatorFND:
+    break;
+  case FndId::fnd_invalid_id:
   default:
-    DBMSG << "dunno but value is " << m_fnd_id << std::endl;
     assert(false);
     break;
   }
@@ -138,7 +189,6 @@ std::string FileNode::to_string()
 
   stream << fnd_id_to_string(m_fnd_id);
   stream << "; ";
-  stream << "size " << m_size_in_file << "; ";
 
   stream << std::hex << "base_type ";
   switch (m_base_type)
@@ -173,7 +223,7 @@ void FileNode::parse_header(const libone::RVNGInputStreamPtr_t &input)
   format_stp = static_cast<stp_format>((temp >> shift_format_stp) & mask_format_stp);
   format_cb = static_cast<cb_format>((temp >> shift_format_cb) & mask_format_cb);
   m_base_type = static_cast<fnd_basetype>((temp >> shift_base_type) & mask_fnd_base_type);
-  m_fnd_id = static_cast<fnd_id>(temp & mask_fnd_id);
+  m_fnd_id = static_cast<FndId>(temp & mask_fnd_id);
   m_size_in_file = (temp >> shift_fnd_size) & mask_fnd_size;
   if (d == 0)
   {

--- a/src/lib/FileNode.h
+++ b/src/lib/FileNode.h
@@ -27,7 +27,7 @@ enum fnd_basetype
   fnd_invalid_basetype
 };
 
-enum fnd_id
+enum class FndId
 {
   ObjectSpaceManifestRootFND                  = 0x004,
   ObjectSpaceManifestListReferenceFND         = 0x008,
@@ -71,7 +71,7 @@ enum fnd_id
   fnd_invalid_id
 };
 
-std::string fnd_id_to_string(enum fnd_id id_fnd);
+std::string fnd_id_to_string(FndId id_fnd);
 
 class FileNode
 {
@@ -81,7 +81,7 @@ public:
 
   void skip_node(const libone::RVNGInputStreamPtr_t &input);
 
-  enum fnd_id get_FileNodeID()
+  FndId get_FileNodeID()
   {
     return m_fnd_id;
   }
@@ -107,7 +107,8 @@ private:
   uint32_t m_offset = 0;
   uint32_t m_size_in_file = 0;
   uint32_t m_header_size = 0;
-  enum fnd_id m_fnd_id = fnd_invalid_id;
+
+  FndId m_fnd_id = FndId::fnd_invalid_id;
   enum fnd_basetype m_base_type = fnd_invalid_basetype;
   void parse_header(const libone::RVNGInputStreamPtr_t &input);
   FileNodeChunkReference m_fnd = FileNodeChunkReference(stp_invalid, cb_invalid, 0);

--- a/src/lib/FileNodeListFragment.cpp
+++ b/src/lib/FileNodeListFragment.cpp
@@ -59,7 +59,7 @@ void FileNodeListFragment::parse(const libone::RVNGInputStreamPtr_t &input)
 
     DBMSG << "input@" << input->tell() << ", node " << node.to_string() << std::endl;
 
-    if (node.get_FileNodeID() != fnd_id::ChunkTerminatorFND)
+    if (node.get_FileNodeID() != FndId::ChunkTerminatorFND)
     {
       m_fnd_list.push_back(node);
       DBMSG << "Added node to node list of size " << m_fnd_list.size() << std::endl;
@@ -101,7 +101,7 @@ void FileNodeListFragment::skip_padding(const libone::RVNGInputStreamPtr_t &inpu
 /* TODO: not sure how to satisfy the 'Transaction' requirement */
 bool FileNodeListFragment::is_end_of_list(FileNode current_node, long current_offset)
 {
-  if (current_node.get_FileNodeID() == fnd_id::ChunkTerminatorFND)
+  if (current_node.get_FileNodeID() == FndId::ChunkTerminatorFND)
   {
     DBMSG << "Returning true because ChunkTerminatorFND" << std::endl;
     return true;

--- a/src/lib/OneNoteParser.cpp
+++ b/src/lib/OneNoteParser.cpp
@@ -80,14 +80,14 @@ void OneNoteParser::parse_root_file_node_list(const libone::RVNGInputStreamPtr_t
 
     switch (node.get_FileNodeID())
     {
-    case ObjectSpaceManifestRootFND:
+    case FndId::ObjectSpaceManifestRootFND:
       input->seek(node.get_location() + node.header_size, librevenge::RVNG_SEEK_SET);
       root_object.parse(input);
       break;
-    case ObjectSpaceManifestListReferenceFND:
+    case FndId::ObjectSpaceManifestListReferenceFND:
       object_space.parse(input, node);
       break;
-    case FileDataStoreListReferenceFND:
+    case FndId::FileDataStoreListReferenceFND:
       break;
     default:
       assert(false);


### PR DESCRIPTION
This has been extracted from #19.

This converts `enum fnd_id` to `enum class FndId`, making the code more readable and less verbose in regards to the `enum` keyword. These changes should not have a functional impact.