### PR TITLE
Refactor FileChunkReference

### DIFF
--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <iostream>
@@ -57,6 +58,7 @@ void FileChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
   case fcr_size_invalid:
   default:
     ONE_DEBUG_MSG(("FileChunkReference: not good!\n"));
+    assert(false);
     break;
   }
 }

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -22,7 +22,6 @@ namespace libone
 FileChunkReference::FileChunkReference(const enum FileChunkReferenceSize fcr_size) :
   m_type(fcr_size),
   m_offset(0),
-  m_size_in_file(0),
   m_stp(0),
   m_cb(0)
 {}
@@ -30,7 +29,6 @@ FileChunkReference::FileChunkReference(const enum FileChunkReferenceSize fcr_siz
 FileChunkReference::FileChunkReference(const uint64_t stp, const uint64_t cb, const enum FileChunkReferenceSize fcr_size) :
   m_type(fcr_size),
   m_offset(0),
-  m_size_in_file(0),
   m_stp(0),
   m_cb(0)
 {
@@ -56,6 +54,7 @@ void FileChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
     m_stp = readU64(input, false);
     m_cb = readU32(input, false);
     break;
+  case fcr_size_invalid:
   default:
     ONE_DEBUG_MSG(("FileChunkReference: not good!\n"));
     break;
@@ -170,13 +169,30 @@ void FileChunkReference::set_zero()
 {
   m_stp = 0;
   m_cb = 0;
-  m_size_in_file = 0;
   m_type = fcr_size_invalid;
 }
 
 // Size of the structure in bytes. Used for seeking
 uint64_t FileChunkReference::get_size_in_file() const
 {
-  return m_size_in_file;
+  uint64_t size = 0;
+  switch (m_type)
+  {
+  case Size32x32:
+    size += 8;
+    break;
+  case Size64x32:
+    size += 12;
+    break;
+  case Size64x64:
+    size += 16;
+    break;
+  case fcr_size_invalid:
+  default:
+    break;
+  }
+
+  return size;
 }
+
 }

--- a/src/lib/FileChunkReference.cpp
+++ b/src/lib/FileChunkReference.cpp
@@ -19,13 +19,24 @@
 namespace libone
 {
 
-FileChunkReference::FileChunkReference(enum FileChunkReferenceSize fcr_size) :
+FileChunkReference::FileChunkReference(const enum FileChunkReferenceSize fcr_size) :
   m_type(fcr_size),
   m_offset(0),
   m_size_in_file(0),
   m_stp(0),
   m_cb(0)
 {}
+
+FileChunkReference::FileChunkReference(const uint64_t stp, const uint64_t cb, const enum FileChunkReferenceSize fcr_size) :
+  m_type(fcr_size),
+  m_offset(0),
+  m_size_in_file(0),
+  m_stp(0),
+  m_cb(0)
+{
+  set_location(stp);
+  set_size(cb);
+}
 
 void FileChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
 {
@@ -51,16 +62,65 @@ void FileChunkReference::parse(const libone::RVNGInputStreamPtr_t &input)
   }
 }
 
-long FileChunkReference::get_location()
+uint64_t FileChunkReference::get_location() const
 {
   return m_stp;
 }
-long FileChunkReference::get_size()
+
+void FileChunkReference::set_location(const uint64_t stp)
+{
+  // making sure, stp is not larger than the fcr type specifies
+  switch (m_type)
+  {
+  case Size32x32:
+    if (stp > 0xFFFFFFFF)
+    {
+      m_stp = 0xFFFFFFFF;
+    }
+    else
+    {
+      m_stp = stp;
+    }
+    break;
+  case Size64x64:
+  case Size64x32:
+  case fcr_size_invalid:
+  default:
+    m_stp = stp;
+    break;
+  }
+}
+
+uint64_t FileChunkReference::get_size() const
 {
   return m_cb;
 }
+void FileChunkReference::set_size(const uint64_t cb)
+{
+  // making sure, stp is not larger than the fcr type specifies
+  switch (m_type)
+  {
+  case Size64x32:
+  case Size32x32:
+    if (cb > 0xFFFFFFFF)
+    {
+      m_cb = 0xFFFFFFFF;
+      ONE_DEBUG_MSG(("Warning: FileChunkReference's cb value too large for its type"));
+    }
+    else
+    {
+      m_cb = cb;
+    }
+    break;
+  case Size64x64:
+  case fcr_size_invalid:
+  default:
+    m_cb = cb;
+    break;
+  }
+}
 
-std::string FileChunkReference::to_string()
+std::string FileChunkReference::to_string() const
 {
   std::stringstream stream;
   if (is_fcrNil()) return "fcrNil";
@@ -86,7 +146,7 @@ std::string FileChunkReference::to_string()
   return stream.str();
 }
 
-bool FileChunkReference::is_fcrNil()
+bool FileChunkReference::is_fcrNil() const
 {
   bool cbval = (m_cb == 0);
   switch (m_type)
@@ -101,7 +161,7 @@ bool FileChunkReference::is_fcrNil()
   }
 }
 
-bool FileChunkReference::is_fcrZero()
+bool FileChunkReference::is_fcrZero() const
 {
   return ((m_stp == 0) && (m_cb == 0));
 }
@@ -115,7 +175,7 @@ void FileChunkReference::set_zero()
 }
 
 // Size of the structure in bytes. Used for seeking
-long FileChunkReference::get_size_in_file()
+uint64_t FileChunkReference::get_size_in_file() const
 {
   return m_size_in_file;
 }

--- a/src/lib/FileChunkReference.h
+++ b/src/lib/FileChunkReference.h
@@ -28,15 +28,13 @@ class FileChunkReference
 {
 public:
   FileChunkReference(const enum FileChunkReferenceSize fcr_size);
-  FileChunkReference(const uint64_t stp, const uint64_t cb, const enum FileChunkReferenceSize fcr_size = Size64x64);
+  FileChunkReference(const uint64_t stp, const uint64_t cb, const enum FileChunkReferenceSize fcr_size = fcr_size_invalid);
 
 
   void parse(const libone::RVNGInputStreamPtr_t &input);
   std::string to_string() const;
   uint64_t get_location() const;
-  void set_location(const uint64_t stp);
   uint64_t get_size() const;
-  void set_size(const uint64_t cb);
   bool is_fcrNil() const;
   bool is_fcrZero() const;
   void set_zero();
@@ -45,9 +43,11 @@ public:
 private:
   enum FileChunkReferenceSize m_type;
   uint64_t m_offset;
-  uint64_t m_size_in_file;
   uint64_t m_stp;
   uint64_t m_cb;
+
+  void set_location(const uint64_t stp);
+  void set_size(const uint64_t cb);
 };
 
 }

--- a/src/lib/FileChunkReference.h
+++ b/src/lib/FileChunkReference.h
@@ -27,22 +27,25 @@ enum FileChunkReferenceSize
 class FileChunkReference
 {
 public:
-  FileChunkReference(enum FileChunkReferenceSize fcr_size);
+  FileChunkReference(const enum FileChunkReferenceSize fcr_size);
+  FileChunkReference(const uint64_t stp, const uint64_t cb, const enum FileChunkReferenceSize fcr_size = Size64x64);
 
 
   void parse(const libone::RVNGInputStreamPtr_t &input);
-  std::string to_string();
-  long get_location();
-  long get_size();
-  bool is_fcrNil();
-  bool is_fcrZero();
+  std::string to_string() const;
+  uint64_t get_location() const;
+  void set_location(const uint64_t stp);
+  uint64_t get_size() const;
+  void set_size(const uint64_t cb);
+  bool is_fcrNil() const;
+  bool is_fcrZero() const;
   void set_zero();
-  long get_size_in_file();
+  uint64_t get_size_in_file() const;
 
 private:
   enum FileChunkReferenceSize m_type;
-  long m_offset;
-  long m_size_in_file;
+  uint64_t m_offset;
+  uint64_t m_size_in_file;
   uint64_t m_stp;
   uint64_t m_cb;
 };


### PR DESCRIPTION
An intermittent change 

- add const qualifiers where appropriate
- explicit integer length
- additional ctor for locations where parsing not applies
- set methods

Further optional changes:

- The new member functions `set_location` and `set_size` could likely be made into private members. Their main task is to make sure the integer width is correct.
- the `m_size_in_file` is dependent of the enum `FileChunkReferenceSize`, so it wouldn't need to be stored as a member. Since it's not set anywhere, `m_size_in_file` is always zero. I'll add another commit if you want to have this changed


